### PR TITLE
Use user-first locators

### DIFF
--- a/services/components/HamburgerMenu.ts
+++ b/services/components/HamburgerMenu.ts
@@ -11,12 +11,12 @@ export class HamburgerMenu {
 
 	constructor(page: Page) {
 		this.page = page;
-		this.menuButton = page.locator('#react-burger-menu-btn');
-		this.inventoryLink = page.locator('[data-test="inventory-sidebar-link"]');
-		this.aboutLink = page.locator('[data-test="about-sidebar-link"]');
-		this.logoutLink = page.locator('[data-test="logout-sidebar-link"]');
-		this.resetAppStateLink = page.locator('[data-test="reset-sidebar-link"]');
-		this.closeMenuButton = page.locator('#react-burger-cross-btn');
+		this.menuButton = page.getByRole('button', { name: 'Open menu' });
+		this.inventoryLink = page.getByRole('link', { name: 'All Items' });
+		this.aboutLink = page.getByRole('link', { name: 'About' });
+		this.logoutLink = page.getByRole('link', { name: 'Logout' });
+		this.resetAppStateLink = page.getByRole('link', { name: 'Reset App State' });
+		this.closeMenuButton = page.getByRole('button', { name: 'Close menu' });
 	}
 
 	async openMenu() {

--- a/services/pages/CartPage.ts
+++ b/services/pages/CartPage.ts
@@ -8,8 +8,8 @@ export class CartPage {
 	readonly cartTitle: Locator;
 	constructor(page: Page) {
 		this.page = page;
-		this.checkoutButton = page.locator('[data-test="checkout"]');
-		this.continueShoppingButton = page.locator('[data-test="continue-shopping"]');
+		this.checkoutButton = page.getByRole('button', { name: 'Checkout' });
+		this.continueShoppingButton = page.getByRole('button', { name: 'Continue shopping' });
 		this.cartItems = page.locator('.inventory_item_name');
 		this.cartTitle = page.locator('[data-test="title"]');
 	}

--- a/services/pages/CheckoutPage.ts
+++ b/services/pages/CheckoutPage.ts
@@ -14,16 +14,16 @@ export class CheckoutPage {
 	readonly errorMessage: Locator;
 	constructor(page: Page) {
 		this.page = page;
-		this.firstNameInput = page.locator('[data-test="firstName"]');
-		this.lastNameInput = page.locator('[data-test="lastName"]');
-		this.postalCodeInput = page.locator('[data-test="postalCode"]');
-		this.continueButton = page.locator('[data-test="continue"]');
-		this.finishButton = page.locator('[data-test="finish"]');
-		this.completeHeader = page.locator('[data-test="complete-header"]');
+		this.firstNameInput = page.getByRole('textbox', { name: 'First Name' });
+		this.lastNameInput = page.getByRole('textbox', { name: 'Last Name' });
+		this.postalCodeInput = page.getByRole('textbox', { name: 'Postal Code' });
+		this.continueButton = page.getByRole('button', { name: 'Continue' });
+		this.finishButton = page.getByRole('button', { name: 'Finish' });
+		this.completeHeader = page.getByRole('heading', { name: 'Thank you for your order' });
 		this.completeText = page.locator('[data-test="complete-text"]');
-		this.cancelButton = page.locator('[data-test="cancel"]');
+		this.cancelButton = page.getByRole('button', { name: 'Cancel' });
 		this.checkoutTitle = page.locator('[data-test="title"]');
-		this.errorMessage = page.locator('[data-test="error"]');
+		this.errorMessage = page.getByText('Error');
 	}
 
 	async fillCheckoutInformation(firstName: string, lastName: string, postalCode: string) {

--- a/services/pages/LoginPage.ts
+++ b/services/pages/LoginPage.ts
@@ -8,10 +8,10 @@ export class LoginPage {
 	readonly errorMessage: Locator;
 	constructor(page: Page) {
 		this.page = page;
-		this.usernameInput = page.locator('[data-test="username"]');
-		this.passwordInput = page.locator('[data-test="password"]');
-		this.loginButton = page.locator('[data-test="login-button"]');
-		this.errorMessage = page.locator('[data-test="error"]');
+		this.usernameInput = page.getByRole('textbox', { name: 'Username' });
+		this.passwordInput = page.getByRole('textbox', { name: 'Password' });
+		this.loginButton = page.getByRole('button', { name: 'Login' });
+		this.errorMessage = page.getByText('Epic sadface:');
 	}
 	async goto() {
 		await this.page.goto('');

--- a/services/pages/ProductPage.ts
+++ b/services/pages/ProductPage.ts
@@ -7,10 +7,10 @@ export class ProductPage {
 	readonly cartLink: Locator;
 	constructor(page: Page) {
 		this.page = page;
-		this.cartIcon = page.locator('[data-test="shopping-cart-badge"]');
-		this.productTitle = page.locator('[data-test="title"]');
-		this.backToProductsButton = page.locator('[data-test="back-to-products"]');
-		this.cartLink = page.locator('[data-test="shopping-cart-link"]');
+		this.cartIcon = page.locator('[data-test="shopping-cart-badge"]'); // nothing better available, can't use user-first locator
+		this.productTitle = page.getByText('Products');
+		this.backToProductsButton = page.getByRole('button', { name: 'Back to products' });
+		this.cartLink = page.locator('.shopping_cart_link');
 	}
 
 	// 產生特定商品的定位器
@@ -20,12 +20,12 @@ export class ProductPage {
 
 	async addProductToCart(productName: string) {
 		const productContainer = this.getProductContainer(productName);
-		await productContainer.locator('.btn_inventory').filter({ hasText: 'Add to cart' }).click();
+		await productContainer.getByRole('button', { name: 'Add to cart' }).click();
 	}
 
 	async verifyItemButtonStatusIsRemove(productName: string) {
 		const productContainer = this.getProductContainer(productName);
-		const removeButton = productContainer.locator('.btn_inventory').filter({ hasText: 'Remove' });
+		const removeButton = productContainer.getByRole('button', { name: 'Remove' });
 		await expect.soft(removeButton).toBeVisible();
 	}
 
@@ -50,12 +50,11 @@ export class ProductPage {
 	}
 
 	async viewProductDetails(productName: string) {
-		const productContainer = this.getProductContainer(productName);
-		await productContainer.locator('[data-test="inventory-item-name"]').click();
+		await this.page.getByText(productName).click();
 	}
 
 	async returnToProductList() {
-		await this.page.locator('[data-test="back-to-products"]').click();
+		await this.backToProductsButton.click();
 	}
 	async verifyOnProductListPage() {
 		await expect.soft(this.productTitle).toHaveText('Products');


### PR DESCRIPTION
優先用user-first locator，css或是html層架構的locate法是逼不得已的手段，舉例來說元件的位置會不斷移動或是attribute動態生成，user-first的概念是使用user實際上接觸的資訊作為locate的方式，同樣一個商店資料的元件位置可能因為其他商店資料經過增刪改而移動，attribute是直接動態生成的，但是user看到的就是這個商店資料的不管名稱也好ID也好，用這個資訊來locate資訊會是playwright官方文件建議end to end測試框架要優先採用的做法。