### PR TITLE
feat: implement dynamic image tag strategy for E2E tests

### DIFF
--- a/.github/workflows/springboot.yml
+++ b/.github/workflows/springboot.yml
@@ -2,6 +2,11 @@ name: Spring Boot API E2E Tests
 on:
   # 支援手動觸發
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Backend image tag to test'
+        required: false
+        default: 'latest'
   # 支援後端連動觸發 (由後端 Action 發送訊號)
   repository_dispatch:
     types: [backend_image_updated]
@@ -22,6 +27,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Set Image Tag
+        id: set-tag
+        run: |
+          # 優先順序：repository_dispatch > workflow_dispatch > 預設 latest
+          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
+            TAG="${{ github.event.client_payload.image_tag }}"
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            TAG="${{ inputs.image_tag }}"
+          else
+            TAG="latest"
+          fi
+          echo "IMAGE_TAG=$TAG" >> $GITHUB_OUTPUT
+          echo "🏷️ Using image tag: $TAG"
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -39,7 +58,9 @@ jobs:
           ORACLE_TEST_PASSWORD: ${{ secrets.DB_PASSWORD }}
           # 這裡也可以順便帶入 GITHUB_REPOSITORY_OWNER 給 Docker Compose 使用
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          IMAGE_TAG: ${{ steps.set-tag.outputs.IMAGE_TAG }}
         run: |
+          echo "🚀 Starting environment with image tag: $IMAGE_TAG"
           # 1. 啟動並等待健康檢查完成
           # --quiet-pull 減少日誌干擾，--wait 會參考你 compose 裡的 healthcheck
           docker compose -f docker-compose.test.yml up -d --wait --quiet-pull

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 services:
   # Service Name: app (Spring Boot 應用)
   app:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-junechen7414}/springboot:latest
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-junechen7414}/springboot:${IMAGE_TAG:-latest}
     pull_policy: always # 確保每次測試都使用最新的映像檔，避免因為舊映像檔導致測試不一致    
     # 容器名稱，方便指令podman ps 等操作識別和管理，不用於真正的網路通信
     container_name: spring-boot-app-test


### PR DESCRIPTION
- Add workflow_dispatch input for manual image tag specification
- Add Set Image Tag step to handle tag from different sources
- Update docker-compose.test.yml to use dynamic IMAGE_TAG
- Support PR-specific tags from backend repository_dispatch
- Maintain backward compatibility with 'latest' as default