### PR TITLE
docs: refactor AGENTS.md + enhance Oracle healthcheck

### DIFF
--- a/.github/instructions/Global.instructions.md
+++ b/.github/instructions/Global.instructions.md
@@ -18,14 +18,37 @@ description: Every conversation
 ## 指令執行偏好
 1. 容器管理工具：一律使用 podman 而非 docker。
 2. 套件管理器：一律使用 pnpm。嚴禁使用 npm 或 yarn。
+3. Shell 環境適配：執行指令前須先偵測當前 Shell（PowerShell 或 CMD），並使用對應語法：
+   - PowerShell (`pwsh`)：指令串接用 `;`，執行當前目錄腳本用 `./script`（例如 `./gradlew`）
+   - CMD (`cmd.exe`)：指令串接用 `&&`，執行當前目錄腳本直接用名稱（例如 `gradlew`，不加 `./`）
+   - 不可假設預設 Shell 環境，須透過環境資訊判斷後再決定指令語法
 
 ## git 命名/訊息偏好
 1. 分支命名 (Branch Naming)
 - **格式：** `類別/任務簡述`
 - **常用前綴：** `feature/` (新功能)、`bugfix/` (修復)、`hotfix/` (緊急修復)、`refactor/` (重構)。
-- **關鍵原則：** 全小寫、使用 `-` 分隔、使用 `/` 分層。
+- **關鍵原則：** 全小寫、使用  分隔、使用 `/` 分層。
 
 2. Commit 訊息 (Conventional Commits)
 - **格式：** `<type>(<scope>): <subject>`
 - **常用類型：** `feat`, `fix`, `docs`, `style`, `refactor`, `chore`。
 - **關鍵原則：** 使用祈使句（如 `add` 而非 `added`）、標題與內容空一行、內容著重「為什麼」而非「怎麼做」。
+
+## 文檔管理規範
+
+1. **文檔放置位置**
+   - 所有專案相關的文檔必須放在 `docs/` 目錄下
+   - 包括但不限於：指南文件、說明文件、流程圖、計劃文件等
+   - 根目錄只保留必要的配置文件（如 README.md、.gitignore 等）
+
+2. **文檔命名規範**
+   - 使用小寫字母和連字符（kebab-case）
+   - 範例：`git-branch-push-plan.md`、`test-profile-configuration-guide.md`
+   - 避免使用空格或特殊字元
+
+3. **文檔類型分類**
+   - 指南類：`*-guide.md`（如 `test-profile-configuration-guide.md`）
+   - 計劃類：`*-plan.md`（如 `git-branch-push-plan.md`、`migration-plan.md`）
+   - 說明類：`*-explanation.md`（如 `docker-compose-test-explanation.md`）
+   - 流程圖：`*-workflow.md` 或 `*-diagram.md`
+   - 快速參考：`*-quick-*.md`（如 `playwright-quick-fix.md`）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,418 +2,42 @@
 
 This file provides guidance to agents when working with code in this repository.
 
-## 專案概述
+---
 
-這是一個使用 **Playwright + TypeScript** 開發的 E2E 自動化測試專案，採用 **Business-Layer Page Object Model** 架構模式。專案整合了 Docker Compose 進行環境管理，並支援 CI/CD 自動化測試流程。
+## 📚 文件導覽
 
-### 核心技術棧
+本文件已模組化，請參考以下分類文件：
 
-- **測試框架**: Playwright v1.57.0
-- **程式語言**: TypeScript (ES Modules)
-- **套件管理**: pnpm
-- **容器管理**: Podman/Docker Compose
-- **CI/CD**: GitHub Actions
-- **測試目標**: 
-  - UI 測試 (SauceDemo)
-  - API 測試 (Spring Boot + Oracle DB)
+### 🚀 專案基礎
 
-### 專案架構原則
+- **[@專案概述](docs/agents/01-project-overview.md)** - 專案簡介、技術棧與架構原則
+- **[@環境準備](docs/agents/02-environment-setup.md)** - 開發環境設定與安裝步驟
+- **[@快速開始](docs/agents/03-quick-start.md)** - 測試執行與常用腳本說明
 
-本專案遵循 **Business-Layer Page-Object Pattern**，核心理念是：
-- 測試腳本應該讀起來像商業流程，而非技術操作
-- 封裝低階操作細節（Locators、Clicks）
-- 使用語意化的方法名稱
-- 讓非技術人員也能理解測試內容
+### 📋 開發規範
 
-## 建置與執行
+- **[@開發規範](docs/agents/04-development-standards.md)** - 語言偏好、工具選擇與 Shell 指令規範
+- **[@Git 工作流程](docs/agents/05-git-workflow.md)** - 分支命名與 Commit 訊息規範
+- **[@程式設計原則](docs/agents/06-coding-principles.md)** - 核心程式設計理念與最佳實踐
 
-### 環境準備
+### 🏗️ 架構設計
 
-```bash
-# 1. 安裝依賴
-pnpm install
+- **[@架構概覽](docs/agents/07-architecture-overview.md)** - 目錄結構與組織方式
+- **[@測試架構](docs/agents/08-test-architecture.md)** - Custom Fixtures 與 Page Object Model 設計
+- **[@元素定位策略](docs/agents/09-locator-strategies.md)** - Playwright 元素定位最佳實踐
 
-# 2. 設定環境變數（複製 .env.example 並修改）
-cp .env.example .env
+### 🧪 測試與部署
 
-# 3. 啟動測試環境（Spring Boot + Oracle DB）
-pnpm run compose-up
-```
+- **[@測試策略](docs/agents/10-testing-strategies.md)** - 資料清理策略與全域登入狀態管理
+- **[@CI/CD 整合](docs/agents/11-cicd-integration.md)** - GitHub Actions 與 Docker Compose 配置
+- **[@配置指南](docs/agents/12-configuration-guide.md)** - Playwright 與 TypeScript 配置說明
 
-### 測試執行
+### 🔧 維運支援
 
-```bash
-# UI 測試（SauceDemo）
-pnpm playwright test --project=ui-staging
+- **[@進階技巧](docs/agents/13-advanced-techniques.md)** - API 型別安全、網路攔截與進階功能
+- **[@疑難排解](docs/agents/14-troubleshooting.md)** - 常見問題與解決方案
 
-# API 測試（Spring Boot）
-pnpm run test:e2e
-
-# 完整 CI/CD 流程（容器重啟 + 測試）
-pnpm run test:e2e:ci
-
-# 或使用腳本
-# Windows
-.\scripts\test-e2e-ci.ps1
-# Linux/macOS
-bash scripts/test-e2e-ci.sh
-```
-
-### 重要腳本說明
-
-| 指令 | 說明 |
-|------|------|
-| `pnpm run compose-up` | 啟動測試環境（Spring Boot + Oracle DB） |
-| `pnpm run compose-down` | 停止並刪除測試環境 |
-| `pnpm run compose-restart` | 重啟測試環境 |
-| `pnpm run test:e2e` | 執行 API E2E 測試 |
-| `pnpm run test:e2e:ci` | 完整 CI/CD 測試流程（容器重啟） |
-| `pnpm run api-spec:update` | 從 Swagger 更新 API 型別定義 |
-| `pnpm run biome:fix` | 自動修復程式碼格式問題 |
-
-## 開發規範
-
-### 語言偏好
-
-- **主要語言**: 繁體中文（正體中文）
-- **次要語言**: 英文（僅在技術術語更清晰時使用）
-- **禁止**: 簡體中文
-
-### 工具偏好
-
-- **容器管理**: 使用 `podman`，不使用 `docker`
-- **套件管理**: 使用 `pnpm`，禁止使用 `npm` 或 `yarn`
-
-### Shell 指令執行規範
-
-執行 CLI 指令前，必須先偵測當前使用的 Shell 環境（PowerShell 或 CMD），並根據環境調整指令語法：
-
-| 差異項目 | PowerShell (`pwsh`) | CMD (`cmd.exe`) |
-|---------|-------------------|-----------------|
-| 指令串接 | 使用 `;` 分隔 | 使用 `&&` 分隔 |
-| 執行當前目錄腳本 | `./gradlew` | `gradlew` (或 `.\gradlew`) |
-| 環境變數引用 | `$env:VAR_NAME` | `%VAR_NAME%` |
-| 路徑分隔 | 支援 `/` 和 `\` | 建議使用 `\` |
-
-**範例對照：**
-- PowerShell：`cd src; ./gradlew test`
-- CMD：`cd src && gradlew test`
-
-**重要原則：**
-- 不可假設預設 Shell，須透過環境資訊判斷
-- 指令語法必須與當前 Shell 相容，避免跨 Shell 語法混用
-
-### Git 規範
-
-**分支命名**:
-- 格式: `類別/任務簡述`
-- 常用前綴: `feature/`, `bugfix/`, `hotfix/`, `refactor/`
-- 規則: 全小寫、使用 `-` 分隔、使用 `/` 分層
-
-**Commit 訊息** (Conventional Commits):
-- 格式: `<type>(<scope>): <subject>`
-- 常用類型: `feat`, `fix`, `docs`, `style`, `refactor`, `chore`
-- 使用祈使句（如 `add` 而非 `added`）
-
-### 程式設計原則
-
-1. **可讀性優先**: 程式碼應該易於理解，即使犧牲簡潔性
-2. **現代化語法**: 使用最新的 TypeScript/JavaScript 語法
-3. **實務導向**: 理論正確但實務不適用的方案應避免
-
-## 架構設計
-
-### 目錄結構
-
-```
-Playwright/
-├── services/              # 核心服務層
-│   ├── apis/             # API 客戶端
-│   ├── components/       # 可重用 UI 元件
-│   ├── fixtures/         # Playwright Fixtures
-│   ├── pages/            # Page Objects
-│   └── schema/           # API 型別定義
-├── tests/                # 測試案例
-│   ├── api/              # API 測試
-│   │   └── springboot/   # Spring Boot API 測試
-│   └── ui/               # UI 測試
-│       └── saucedemo/    # SauceDemo UI 測試
-├── init-scripts/         # Oracle DB 初始化腳本
-├── scripts/              # 測試執行腳本
-└── .github/              # CI/CD 配置
-    └── workflows/        # GitHub Actions
-```
-
-### Custom Fixtures 架構
-
-本專案使用 Playwright 的 Fixture 系統來管理測試依賴：
-
-**核心優勢**:
-1. **封裝與可重用性**: 將準備工作與測試內容分離
-2. **依賴注入**: 自動執行初始化邏輯
-3. **按需執行**: 只有測試用到的 Fixture 才會執行（與 `beforeEach` 不同）
-
-**Fixture 類型**:
-- `page-objects.fixture.ts`: 封裝 UI 頁面物件
-- `springboot-api-objects.fixture.ts`: 封裝 API 客戶端
-- `saucedemo-test-data.fixture.ts`: 封裝測試資料
-- `chain-fixtures.fixture.ts`: 使用 `mergeTests` 整合所有 Fixtures
-
-**使用範例**:
-```typescript
-import { test, expect } from '../fixtures/chain-fixtures';
-
-test('範例測試', async ({ loginPage, standardUserData }) => {
-  await loginPage.login(standardUserData.username, standardUserData.password);
-  // Fixtures 自動注入，無需手動初始化
-});
-```
-
-### Page Object Model 設計
-
-**核心原則**:
-1. **封裝低階操作**: 不暴露 Locators 和 `page.click()` 等細節
-2. **商業邏輯導向**: 方法名稱反映使用者行為，而非 UI 操作
-3. **隱藏斷言細節**: 將驗證邏輯封裝進 Page Object
-
-**範例**:
-```typescript
-// ✅ 好的做法：語意化方法
-await checkoutPage.fillCheckoutInformation('John', 'Doe', '12345');
-await checkoutPage.continueCheckout();
-await checkoutPage.finishCheckout();
-await checkoutPage.verifyOrderCompletion();
-
-// ❌ 避免：暴露技術細節
-await page.getByLabel('First Name').fill('John');
-await page.getByLabel('Last Name').fill('Doe');
-await page.getByRole('button', { name: 'Continue' }).click();
-```
-
-### 元素定位最佳實踐
-
-**優先順序** (由高到低):
-1. `page.getByRole(role, { name })` - 最穩健，符合無障礙設計
-2. `page.getByText(text)` - 透過顯示文字定位
-3. `page.getByLabel(label)` - 適用於表單輸入
-4. `page.getByPlaceholder(text)` - 無 Label 時使用
-
-**使用 Chrome DevTools 查看 Accessibility**:
-1. 開啟 DevTools (F12)
-2. 切換到 **Accessibility** 面板
-3. 查看 **Role** 和 **Name** 屬性
-4. 使用這些資訊構建 `getByRole` 定位器
-
-## 測試策略
-
-### 資料清理策略
-
-本專案採用 **容器重啟策略** 確保測試隔離性：
-
-**工作原理**:
-1. 每次測試前停止並刪除所有容器和 volumes
-2. 重新啟動 Docker Compose 環境
-3. Spring Boot 自動執行 Flyway migrate
-4. 等待健康檢查通過後執行測試
-
-**優點**:
-- ✅ 完全隔離，每次都是全新環境
-- ✅ 不依賴額外工具（如 Flyway CLI）
-- ✅ 適合 CI/CD pipeline
-- ✅ 測試結果可重複且可靠
-
-**缺點**:
-- ⏱️ 啟動時間較長（Oracle DB 需要 1-2 分鐘）
-
-詳細說明請參考: [E2E-TESTING-CLEANUP-STRATEGY.md](./E2E-TESTING-CLEANUP-STRATEGY.md)
-
-### 全域登入狀態分享
-
-使用 `storageState` 避免每個測試重複登入：
-
-1. Setup 測試執行登入並儲存狀態
-2. 主測試設定 `dependencies: ['ui-setup']`
-3. 自動注入登入狀態到所有測試
-
-**配置** (playwright.config.ts):
-```typescript
-projects: [
-  {
-    name: 'ui-setup',
-    testMatch: '**/saucedemo/*.setup.ts',
-  },
-  {
-    name: 'ui-staging',
-    testMatch: '**/saucedemo/*.spec.ts',
-    dependencies: ['ui-setup'], // 依賴 Setup
-  },
-]
-```
-
-## CI/CD 整合
-
-### GitHub Actions 配置
-
-本專案使用 GitHub Actions 進行自動化測試，關鍵特點：
-
-**容器化執行**:
-- 使用官方 Playwright Docker 映像檔
-- 預先安裝瀏覽器，省去下載時間
-- 確保環境一致性
-
-**觸發條件**:
-- Pull Request 合併至 `main` 或 `master`
-- 手動觸發 (`workflow_dispatch`)
-- 後端專案觸發 (`repository_dispatch`)
-
-**環境變數管理**:
-- 使用 GitHub Secrets 儲存敏感資訊
-- `DB_USER`: 資料庫使用者名稱
-- `DB_PASSWORD`: 資料庫密碼
-
-**關鍵步驟**:
-1. 登入 GHCR (GitHub Container Registry)
-2. 啟動 Docker Compose 環境並等待健康檢查
-3. 執行 Playwright 測試
-4. 上傳測試報告
-
-### Docker Compose 配置
-
-**服務架構**:
-- `app`: Spring Boot 應用 (Port 8787)
-- `oracle-db`: Oracle Database Free (Port 1521)
-
-**環境變數配置**:
-```yaml
-environment:
-  - SPRING_DATASOURCE_URL=jdbc:oracle:thin:@oracle-db:1521/FREEPDB1
-  - SPRING_DATASOURCE_USERNAME=${ORACLE_TEST_USERNAME}
-  - SPRING_DATASOURCE_PASSWORD=${ORACLE_TEST_PASSWORD}
-```
-
-**健康檢查**:
-- Oracle DB: 檢查 PDB 是否處於 READ WRITE 模式
-- 使用 SYS 使用者，避免時序問題
-
-**初始化流程**:
-1. Oracle DB 啟動
-2. 執行 `init-scripts/01_setup.sh` 創建測試使用者
-3. Spring Boot 連接資料庫並執行 Flyway migrate
-
-## 進階技巧
-
-### API 型別安全
-
-使用 `openapi-typescript` 從 Swagger 自動生成型別定義：
-
-```bash
-pnpm run api-spec:update
-```
-
-生成的型別檔案: `services/schema/api-types.ts`
-
-### 網路攔截與 Mocking
-
-使用 `page.route` 攔截網路請求並偽造回應：
-
-```typescript
-// 模擬 API 錯誤
-await page.route('**/api/user', async route => {
-  await route.fulfill({
-    status: 500,
-    contentType: 'application/json',
-    body: JSON.stringify({ message: 'Internal Server Error' }),
-  });
-});
-```
-
-**適用情境**:
-- 測試錯誤處理邏輯
-- 固定測試資料
-- 模擬網路中斷
-
-### 自動處理隨機彈窗
-
-使用 `addLocatorHandler` 處理隨機出現的元素：
-
-```typescript
-await page.addLocatorHandler(
-  page.getByRole('button', { name: '同意' }),
-  async () => {
-    await page.getByRole('button', { name: '關閉' }).click();
-  }
-);
-```
-
-### 斷言技巧
-
-**軟斷言** (`expect.soft`):
-- 失敗時不中止測試，繼續執行後續步驟
-- 適合單一測試有多個檢查點
-
-**API 狀態驗證** (`expect.toBeOK`):
-- 驗證 Response Status Code 是否在 200-299 之間
-
-## 配置檔案說明
-
-### playwright.config.ts
-
-**動態報告路徑**:
-- 本地: `playwright-report/2024-05-20_14-30-00/`
-- CI: `playwright-report/`
-
-**CI/CD 策略差異**:
-
-| 設定項目 | CI 環境 | 本機開發 |
-|---------|---------|----------|
-| Retries | 2 次 | 0 次 |
-| Workers | 2 | 3 |
-| Reporter | List + HTML | List + HTML (時間戳記) |
-| Video/Trace | Retain on Failure | Off |
-
-**專案依賴**:
-```typescript
-projects: [
-  { name: 'ui-setup', testMatch: '**/saucedemo/*.setup.ts' },
-  { 
-    name: 'ui-staging', 
-    dependencies: ['ui-setup'], // 先執行 Setup
-  },
-]
-```
-
-### tsconfig.json
-
-使用現代化 TypeScript 配置：
-- `module: "esnext"` - ES 模組支援
-- `moduleResolution: "bundler"` - 現代模組解析
-- `strict: true` - 嚴格型別檢查
-- `noUncheckedIndexedAccess: true` - 陣列存取安全
-
-## 疑難排解
-
-### 容器啟動失敗
-
-**檢查項目**:
-1. 確認 Podman/Docker 正在運行
-2. 檢查 `.env` 檔案是否存在且正確
-3. 查看容器日誌: `podman logs spring-boot-app-test`
-
-### 測試連線失敗
-
-**錯誤訊息**: `connect ECONNREFUSED ::1:8787`
-
-**解決方式**:
-1. 確認容器正在運行: `podman ps`
-2. 等待 Spring Boot 完全啟動（10-20 秒）
-3. 檢查 port 8787 是否被佔用
-
-### Oracle DB 啟動超時
-
-**解決方式**:
-1. 增加等待時間（調整測試腳本中的 `maxWait`）
-2. 確認系統資源充足（Oracle DB 需要較多記憶體）
-3. 檢查 Oracle DB 日誌: `podman logs oracle-db-test`
+---
 
 ## 相關文件
 
@@ -435,6 +59,6 @@ projects: [
 
 ---
 
-**最後更新**: 2026-05-27  
+**最後更新**: 2026-06-01  
 **專案版本**: 1.0.0  
 **Playwright 版本**: 1.57.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,440 @@
+# AGENTS.md
+
+This file provides guidance to agents when working with code in this repository.
+
+## 專案概述
+
+這是一個使用 **Playwright + TypeScript** 開發的 E2E 自動化測試專案，採用 **Business-Layer Page Object Model** 架構模式。專案整合了 Docker Compose 進行環境管理，並支援 CI/CD 自動化測試流程。
+
+### 核心技術棧
+
+- **測試框架**: Playwright v1.57.0
+- **程式語言**: TypeScript (ES Modules)
+- **套件管理**: pnpm
+- **容器管理**: Podman/Docker Compose
+- **CI/CD**: GitHub Actions
+- **測試目標**: 
+  - UI 測試 (SauceDemo)
+  - API 測試 (Spring Boot + Oracle DB)
+
+### 專案架構原則
+
+本專案遵循 **Business-Layer Page-Object Pattern**，核心理念是：
+- 測試腳本應該讀起來像商業流程，而非技術操作
+- 封裝低階操作細節（Locators、Clicks）
+- 使用語意化的方法名稱
+- 讓非技術人員也能理解測試內容
+
+## 建置與執行
+
+### 環境準備
+
+```bash
+# 1. 安裝依賴
+pnpm install
+
+# 2. 設定環境變數（複製 .env.example 並修改）
+cp .env.example .env
+
+# 3. 啟動測試環境（Spring Boot + Oracle DB）
+pnpm run compose-up
+```
+
+### 測試執行
+
+```bash
+# UI 測試（SauceDemo）
+pnpm playwright test --project=ui-staging
+
+# API 測試（Spring Boot）
+pnpm run test:e2e
+
+# 完整 CI/CD 流程（容器重啟 + 測試）
+pnpm run test:e2e:ci
+
+# 或使用腳本
+# Windows
+.\scripts\test-e2e-ci.ps1
+# Linux/macOS
+bash scripts/test-e2e-ci.sh
+```
+
+### 重要腳本說明
+
+| 指令 | 說明 |
+|------|------|
+| `pnpm run compose-up` | 啟動測試環境（Spring Boot + Oracle DB） |
+| `pnpm run compose-down` | 停止並刪除測試環境 |
+| `pnpm run compose-restart` | 重啟測試環境 |
+| `pnpm run test:e2e` | 執行 API E2E 測試 |
+| `pnpm run test:e2e:ci` | 完整 CI/CD 測試流程（容器重啟） |
+| `pnpm run api-spec:update` | 從 Swagger 更新 API 型別定義 |
+| `pnpm run biome:fix` | 自動修復程式碼格式問題 |
+
+## 開發規範
+
+### 語言偏好
+
+- **主要語言**: 繁體中文（正體中文）
+- **次要語言**: 英文（僅在技術術語更清晰時使用）
+- **禁止**: 簡體中文
+
+### 工具偏好
+
+- **容器管理**: 使用 `podman`，不使用 `docker`
+- **套件管理**: 使用 `pnpm`，禁止使用 `npm` 或 `yarn`
+
+### Shell 指令執行規範
+
+執行 CLI 指令前，必須先偵測當前使用的 Shell 環境（PowerShell 或 CMD），並根據環境調整指令語法：
+
+| 差異項目 | PowerShell (`pwsh`) | CMD (`cmd.exe`) |
+|---------|-------------------|-----------------|
+| 指令串接 | 使用 `;` 分隔 | 使用 `&&` 分隔 |
+| 執行當前目錄腳本 | `./gradlew` | `gradlew` (或 `.\gradlew`) |
+| 環境變數引用 | `$env:VAR_NAME` | `%VAR_NAME%` |
+| 路徑分隔 | 支援 `/` 和 `\` | 建議使用 `\` |
+
+**範例對照：**
+- PowerShell：`cd src; ./gradlew test`
+- CMD：`cd src && gradlew test`
+
+**重要原則：**
+- 不可假設預設 Shell，須透過環境資訊判斷
+- 指令語法必須與當前 Shell 相容，避免跨 Shell 語法混用
+
+### Git 規範
+
+**分支命名**:
+- 格式: `類別/任務簡述`
+- 常用前綴: `feature/`, `bugfix/`, `hotfix/`, `refactor/`
+- 規則: 全小寫、使用 `-` 分隔、使用 `/` 分層
+
+**Commit 訊息** (Conventional Commits):
+- 格式: `<type>(<scope>): <subject>`
+- 常用類型: `feat`, `fix`, `docs`, `style`, `refactor`, `chore`
+- 使用祈使句（如 `add` 而非 `added`）
+
+### 程式設計原則
+
+1. **可讀性優先**: 程式碼應該易於理解，即使犧牲簡潔性
+2. **現代化語法**: 使用最新的 TypeScript/JavaScript 語法
+3. **實務導向**: 理論正確但實務不適用的方案應避免
+
+## 架構設計
+
+### 目錄結構
+
+```
+Playwright/
+├── services/              # 核心服務層
+│   ├── apis/             # API 客戶端
+│   ├── components/       # 可重用 UI 元件
+│   ├── fixtures/         # Playwright Fixtures
+│   ├── pages/            # Page Objects
+│   └── schema/           # API 型別定義
+├── tests/                # 測試案例
+│   ├── api/              # API 測試
+│   │   └── springboot/   # Spring Boot API 測試
+│   └── ui/               # UI 測試
+│       └── saucedemo/    # SauceDemo UI 測試
+├── init-scripts/         # Oracle DB 初始化腳本
+├── scripts/              # 測試執行腳本
+└── .github/              # CI/CD 配置
+    └── workflows/        # GitHub Actions
+```
+
+### Custom Fixtures 架構
+
+本專案使用 Playwright 的 Fixture 系統來管理測試依賴：
+
+**核心優勢**:
+1. **封裝與可重用性**: 將準備工作與測試內容分離
+2. **依賴注入**: 自動執行初始化邏輯
+3. **按需執行**: 只有測試用到的 Fixture 才會執行（與 `beforeEach` 不同）
+
+**Fixture 類型**:
+- `page-objects.fixture.ts`: 封裝 UI 頁面物件
+- `springboot-api-objects.fixture.ts`: 封裝 API 客戶端
+- `saucedemo-test-data.fixture.ts`: 封裝測試資料
+- `chain-fixtures.fixture.ts`: 使用 `mergeTests` 整合所有 Fixtures
+
+**使用範例**:
+```typescript
+import { test, expect } from '../fixtures/chain-fixtures';
+
+test('範例測試', async ({ loginPage, standardUserData }) => {
+  await loginPage.login(standardUserData.username, standardUserData.password);
+  // Fixtures 自動注入，無需手動初始化
+});
+```
+
+### Page Object Model 設計
+
+**核心原則**:
+1. **封裝低階操作**: 不暴露 Locators 和 `page.click()` 等細節
+2. **商業邏輯導向**: 方法名稱反映使用者行為，而非 UI 操作
+3. **隱藏斷言細節**: 將驗證邏輯封裝進 Page Object
+
+**範例**:
+```typescript
+// ✅ 好的做法：語意化方法
+await checkoutPage.fillCheckoutInformation('John', 'Doe', '12345');
+await checkoutPage.continueCheckout();
+await checkoutPage.finishCheckout();
+await checkoutPage.verifyOrderCompletion();
+
+// ❌ 避免：暴露技術細節
+await page.getByLabel('First Name').fill('John');
+await page.getByLabel('Last Name').fill('Doe');
+await page.getByRole('button', { name: 'Continue' }).click();
+```
+
+### 元素定位最佳實踐
+
+**優先順序** (由高到低):
+1. `page.getByRole(role, { name })` - 最穩健，符合無障礙設計
+2. `page.getByText(text)` - 透過顯示文字定位
+3. `page.getByLabel(label)` - 適用於表單輸入
+4. `page.getByPlaceholder(text)` - 無 Label 時使用
+
+**使用 Chrome DevTools 查看 Accessibility**:
+1. 開啟 DevTools (F12)
+2. 切換到 **Accessibility** 面板
+3. 查看 **Role** 和 **Name** 屬性
+4. 使用這些資訊構建 `getByRole` 定位器
+
+## 測試策略
+
+### 資料清理策略
+
+本專案採用 **容器重啟策略** 確保測試隔離性：
+
+**工作原理**:
+1. 每次測試前停止並刪除所有容器和 volumes
+2. 重新啟動 Docker Compose 環境
+3. Spring Boot 自動執行 Flyway migrate
+4. 等待健康檢查通過後執行測試
+
+**優點**:
+- ✅ 完全隔離，每次都是全新環境
+- ✅ 不依賴額外工具（如 Flyway CLI）
+- ✅ 適合 CI/CD pipeline
+- ✅ 測試結果可重複且可靠
+
+**缺點**:
+- ⏱️ 啟動時間較長（Oracle DB 需要 1-2 分鐘）
+
+詳細說明請參考: [E2E-TESTING-CLEANUP-STRATEGY.md](./E2E-TESTING-CLEANUP-STRATEGY.md)
+
+### 全域登入狀態分享
+
+使用 `storageState` 避免每個測試重複登入：
+
+1. Setup 測試執行登入並儲存狀態
+2. 主測試設定 `dependencies: ['ui-setup']`
+3. 自動注入登入狀態到所有測試
+
+**配置** (playwright.config.ts):
+```typescript
+projects: [
+  {
+    name: 'ui-setup',
+    testMatch: '**/saucedemo/*.setup.ts',
+  },
+  {
+    name: 'ui-staging',
+    testMatch: '**/saucedemo/*.spec.ts',
+    dependencies: ['ui-setup'], // 依賴 Setup
+  },
+]
+```
+
+## CI/CD 整合
+
+### GitHub Actions 配置
+
+本專案使用 GitHub Actions 進行自動化測試，關鍵特點：
+
+**容器化執行**:
+- 使用官方 Playwright Docker 映像檔
+- 預先安裝瀏覽器，省去下載時間
+- 確保環境一致性
+
+**觸發條件**:
+- Pull Request 合併至 `main` 或 `master`
+- 手動觸發 (`workflow_dispatch`)
+- 後端專案觸發 (`repository_dispatch`)
+
+**環境變數管理**:
+- 使用 GitHub Secrets 儲存敏感資訊
+- `DB_USER`: 資料庫使用者名稱
+- `DB_PASSWORD`: 資料庫密碼
+
+**關鍵步驟**:
+1. 登入 GHCR (GitHub Container Registry)
+2. 啟動 Docker Compose 環境並等待健康檢查
+3. 執行 Playwright 測試
+4. 上傳測試報告
+
+### Docker Compose 配置
+
+**服務架構**:
+- `app`: Spring Boot 應用 (Port 8787)
+- `oracle-db`: Oracle Database Free (Port 1521)
+
+**環境變數配置**:
+```yaml
+environment:
+  - SPRING_DATASOURCE_URL=jdbc:oracle:thin:@oracle-db:1521/FREEPDB1
+  - SPRING_DATASOURCE_USERNAME=${ORACLE_TEST_USERNAME}
+  - SPRING_DATASOURCE_PASSWORD=${ORACLE_TEST_PASSWORD}
+```
+
+**健康檢查**:
+- Oracle DB: 檢查 PDB 是否處於 READ WRITE 模式
+- 使用 SYS 使用者，避免時序問題
+
+**初始化流程**:
+1. Oracle DB 啟動
+2. 執行 `init-scripts/01_setup.sh` 創建測試使用者
+3. Spring Boot 連接資料庫並執行 Flyway migrate
+
+## 進階技巧
+
+### API 型別安全
+
+使用 `openapi-typescript` 從 Swagger 自動生成型別定義：
+
+```bash
+pnpm run api-spec:update
+```
+
+生成的型別檔案: `services/schema/api-types.ts`
+
+### 網路攔截與 Mocking
+
+使用 `page.route` 攔截網路請求並偽造回應：
+
+```typescript
+// 模擬 API 錯誤
+await page.route('**/api/user', async route => {
+  await route.fulfill({
+    status: 500,
+    contentType: 'application/json',
+    body: JSON.stringify({ message: 'Internal Server Error' }),
+  });
+});
+```
+
+**適用情境**:
+- 測試錯誤處理邏輯
+- 固定測試資料
+- 模擬網路中斷
+
+### 自動處理隨機彈窗
+
+使用 `addLocatorHandler` 處理隨機出現的元素：
+
+```typescript
+await page.addLocatorHandler(
+  page.getByRole('button', { name: '同意' }),
+  async () => {
+    await page.getByRole('button', { name: '關閉' }).click();
+  }
+);
+```
+
+### 斷言技巧
+
+**軟斷言** (`expect.soft`):
+- 失敗時不中止測試，繼續執行後續步驟
+- 適合單一測試有多個檢查點
+
+**API 狀態驗證** (`expect.toBeOK`):
+- 驗證 Response Status Code 是否在 200-299 之間
+
+## 配置檔案說明
+
+### playwright.config.ts
+
+**動態報告路徑**:
+- 本地: `playwright-report/2024-05-20_14-30-00/`
+- CI: `playwright-report/`
+
+**CI/CD 策略差異**:
+
+| 設定項目 | CI 環境 | 本機開發 |
+|---------|---------|----------|
+| Retries | 2 次 | 0 次 |
+| Workers | 2 | 3 |
+| Reporter | List + HTML | List + HTML (時間戳記) |
+| Video/Trace | Retain on Failure | Off |
+
+**專案依賴**:
+```typescript
+projects: [
+  { name: 'ui-setup', testMatch: '**/saucedemo/*.setup.ts' },
+  { 
+    name: 'ui-staging', 
+    dependencies: ['ui-setup'], // 先執行 Setup
+  },
+]
+```
+
+### tsconfig.json
+
+使用現代化 TypeScript 配置：
+- `module: "esnext"` - ES 模組支援
+- `moduleResolution: "bundler"` - 現代模組解析
+- `strict: true` - 嚴格型別檢查
+- `noUncheckedIndexedAccess: true` - 陣列存取安全
+
+## 疑難排解
+
+### 容器啟動失敗
+
+**檢查項目**:
+1. 確認 Podman/Docker 正在運行
+2. 檢查 `.env` 檔案是否存在且正確
+3. 查看容器日誌: `podman logs spring-boot-app-test`
+
+### 測試連線失敗
+
+**錯誤訊息**: `connect ECONNREFUSED ::1:8787`
+
+**解決方式**:
+1. 確認容器正在運行: `podman ps`
+2. 等待 Spring Boot 完全啟動（10-20 秒）
+3. 檢查 port 8787 是否被佔用
+
+### Oracle DB 啟動超時
+
+**解決方式**:
+1. 增加等待時間（調整測試腳本中的 `maxWait`）
+2. 確認系統資源充足（Oracle DB 需要較多記憶體）
+3. 檢查 Oracle DB 日誌: `podman logs oracle-db-test`
+
+## 相關文件
+
+- [筆記.md](./筆記.md) - 詳細的開發指南和最佳實踐
+- [E2E-TESTING-CLEANUP-STRATEGY.md](./E2E-TESTING-CLEANUP-STRATEGY.md) - 測試資料清理策略
+- [.github/instructions/Global.instructions.md](./.github/instructions/Global.instructions.md) - 開發規範
+- [Playwright 官方文件](https://playwright.dev/docs/intro)
+- [Docker Compose 文件](https://docs.docker.com/compose/)
+
+## 重要提醒
+
+1. **不要使用 `npm` 或 `yarn`**: 本專案統一使用 `pnpm`
+2. **不要使用 `docker`**: 本專案統一使用 `podman`
+3. **遵循 Business-Layer POM**: 測試應該讀起來像商業流程
+4. **使用 Custom Fixtures**: 避免在測試中重複初始化邏輯
+5. **優先使用 `getByRole`**: 最穩健的元素定位方式
+6. **容器重啟策略**: 確保測試隔離性和可重複性
+7. **繁體中文優先**: 所有註解和文件使用繁體中文
+
+---
+
+**最後更新**: 2026-05-27  
+**專案版本**: 1.0.0  
+**Playwright 版本**: 1.57.0

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,7 +37,49 @@ services:
       # 存放範本檔案 (掛載到另一個自定義目錄)
       - ./init-scripts-template:/opt/oracle/template
     healthcheck:
-      test: ["CMD-SHELL", "sqlplus -S / as sysdba <<EOF\nSET PAGESIZE 0 FEEDBACK OFF\nSELECT open_mode FROM v\\$$pdbs WHERE name='FREEPDB1';\nEXIT;\nEOF | grep -q 'READ WRITE'"]
+      # 三階段健康檢查：PDB 開啟 + 使用者建立 + Listener 註冊服務
+      test: 
+        - "CMD-SHELL"
+        - |
+          # 1. 檢查 PDB 是否處於 READ WRITE 模式
+          PDB_STATUS=$$(sqlplus -S / as sysdba <<'EOSQL'
+          SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF
+          SELECT open_mode FROM v$$pdbs WHERE name='FREEPDB1';
+          EXIT;
+          EOSQL
+          )
+          
+          if ! echo "$$PDB_STATUS" | grep -q 'READ WRITE'; then
+            echo "PDB not ready"
+            exit 1
+          fi
+          
+          # 2. 檢查測試使用者是否已建立
+          USER_EXISTS=$$(sqlplus -S / as sysdba <<'EOSQL'
+          SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF
+          ALTER SESSION SET CONTAINER = FREEPDB1;
+          SELECT COUNT(*) FROM dba_users WHERE username = UPPER('${ORACLE_TEST_USERNAME}');
+          EXIT;
+          EOSQL
+          )
+          
+          USER_EXISTS=$$(echo "$$USER_EXISTS" | tr -d '[:space:]')
+          
+          if [ "$$USER_EXISTS" != "1" ]; then
+            echo "Test user not created yet"
+            exit 1
+          fi
+          
+          # 3. 檢查 Listener 是否已註冊 FREEPDB1 服務
+          LISTENER_STATUS=$$(lsnrctl status | grep -i "FREEPDB1" | wc -l)
+          
+          if [ "$$LISTENER_STATUS" -eq "0" ]; then
+            echo "FREEPDB1 service not registered with listener"
+            exit 1
+          fi
+          
+          echo "Database fully ready"
+          exit 0
       interval: 30s
       timeout: 10s
       retries: 20

--- a/docs/agents/01-project-overview.md
+++ b/docs/agents/01-project-overview.md
@@ -1,0 +1,32 @@
+# 專案概述
+
+> 本文件說明專案的核心技術棧與架構原則
+
+## 專案簡介
+
+這是一個使用 **Playwright + TypeScript** 開發的 E2E 自動化測試專案，採用 **Business-Layer Page Object Model** 架構模式。專案整合了 Docker Compose 進行環境管理，並支援 CI/CD 自動化測試流程。
+
+## 核心技術棧
+
+- **測試框架**: Playwright v1.57.0
+- **程式語言**: TypeScript (ES Modules)
+- **套件管理**: pnpm
+- **容器管理**: Podman/Docker Compose
+- **CI/CD**: GitHub Actions
+- **測試目標**: 
+  - UI 測試 (SauceDemo)
+  - API 測試 (Spring Boot + Oracle DB)
+
+## 專案架構原則
+
+本專案遵循 **Business-Layer Page-Object Pattern**，核心理念是：
+- 測試腳本應該讀起來像商業流程，而非技術操作
+- 封裝低階操作細節（Locators、Clicks）
+- 使用語意化的方法名稱
+- 讓非技術人員也能理解測試內容
+
+## 相關文件
+
+- [環境準備](./02-environment-setup.md)
+- [快速開始](./03-quick-start.md)
+- [架構設計](./07-architecture-overview.md)

--- a/docs/agents/02-environment-setup.md
+++ b/docs/agents/02-environment-setup.md
@@ -1,0 +1,52 @@
+# 環境準備
+
+> 本文件說明如何設定開發與測試環境
+
+## 安裝步驟
+
+### 1. 安裝依賴
+
+```bash
+pnpm install
+```
+
+### 2. 設定環境變數
+
+複製 `.env.example` 並修改為 `.env`：
+
+```bash
+cp .env.example .env
+```
+
+### 3. 啟動測試環境
+
+啟動 Spring Boot + Oracle DB 測試環境：
+
+```bash
+pnpm run compose-up
+```
+
+## 環境需求
+
+- **Node.js**: v18 或更高版本
+- **pnpm**: 最新版本
+- **Podman/Docker**: 用於容器管理
+- **作業系統**: Windows、macOS 或 Linux
+
+## 驗證環境
+
+確認環境設定正確：
+
+```bash
+# 檢查容器狀態
+podman ps
+
+# 檢查 Spring Boot 健康狀態
+curl http://localhost:8787/actuator/health
+```
+
+## 相關文件
+
+- [專案概述](./01-project-overview.md)
+- [快速開始](./03-quick-start.md)
+- [疑難排解](./14-troubleshooting.md)

--- a/docs/agents/03-quick-start.md
+++ b/docs/agents/03-quick-start.md
@@ -1,0 +1,66 @@
+# 快速開始
+
+> 本文件說明如何執行測試與常用腳本
+
+## 測試執行
+
+### UI 測試（SauceDemo）
+
+```bash
+pnpm playwright test --project=ui-staging
+```
+
+### API 測試（Spring Boot）
+
+```bash
+pnpm run test:e2e
+```
+
+### 完整 CI/CD 流程
+
+執行容器重啟 + 測試的完整流程：
+
+```bash
+pnpm run test:e2e:ci
+```
+
+或使用腳本：
+
+```bash
+# Windows
+.\scripts\test-e2e-ci.ps1
+
+# Linux/macOS
+bash scripts/test-e2e-ci.sh
+```
+
+## 重要腳本說明
+
+| 指令 | 說明 |
+|------|------|
+| `pnpm run compose-up` | 啟動測試環境（Spring Boot + Oracle DB） |
+| `pnpm run compose-down` | 停止並刪除測試環境 |
+| `pnpm run compose-restart` | 重啟測試環境 |
+| `pnpm run test:e2e` | 執行 API E2E 測試 |
+| `pnpm run test:e2e:ci` | 完整 CI/CD 測試流程（容器重啟） |
+| `pnpm run api-spec:update` | 從 Swagger 更新 API 型別定義 |
+| `pnpm run biome:fix` | 自動修復程式碼格式問題 |
+
+## 測試報告
+
+測試完成後，可以查看 HTML 報告：
+
+```bash
+# 開啟測試報告
+pnpm playwright show-report
+```
+
+報告位置：
+- **本地開發**: `playwright-report/2024-05-20_14-30-00/`
+- **CI 環境**: `playwright-report/`
+
+## 相關文件
+
+- [環境準備](./02-environment-setup.md)
+- [測試策略](./10-testing-strategies.md)
+- [CI/CD 整合](./11-cicd-integration.md)

--- a/docs/agents/04-development-standards.md
+++ b/docs/agents/04-development-standards.md
@@ -1,0 +1,57 @@
+# 開發規範
+
+> 本文件說明專案的語言、工具與 Shell 指令執行規範
+
+## 語言偏好
+
+- **主要語言**: 繁體中文（正體中文）
+- **次要語言**: 英文（僅在技術術語更清晰時使用）
+- **禁止**: 簡體中文
+
+## 工具偏好
+
+- **容器管理**: 使用 `podman`，不使用 `docker`
+- **套件管理**: 使用 `pnpm`，禁止使用 `npm` 或 `yarn`
+
+## Shell 指令執行規範
+
+執行 CLI 指令前，必須先偵測當前使用的 Shell 環境（PowerShell 或 CMD），並根據環境調整指令語法：
+
+### Shell 差異對照表
+
+| 差異項目 | PowerShell (`pwsh`) | CMD (`cmd.exe`) |
+|---------|-------------------|-----------------|
+| 指令串接 | 使用 `;` 分隔 | 使用 `&&` 分隔 |
+| 執行當前目錄腳本 | `./gradlew` | `gradlew` (或 `.\gradlew`) |
+| 環境變數引用 | `$env:VAR_NAME` | `%VAR_NAME%` |
+| 路徑分隔 | 支援 `/` 和 `\` | 建議使用 `\` |
+
+### 範例對照
+
+**PowerShell**:
+```powershell
+cd src; ./gradlew test
+```
+
+**CMD**:
+```cmd
+cd src && gradlew test
+```
+
+### 重要原則
+
+- ❌ 不可假設預設 Shell，須透過環境資訊判斷
+- ✅ 指令語法必須與當前 Shell 相容，避免跨 Shell 語法混用
+- ✅ 優先使用 PowerShell 語法（本專案主要開發環境）
+
+## 程式碼風格
+
+- 使用 Biome 進行程式碼格式化與 Linting
+- 執行 `pnpm run biome:fix` 自動修復格式問題
+- 遵循 TypeScript 嚴格模式規範
+
+## 相關文件
+
+- [Git 工作流程](./05-git-workflow.md)
+- [程式設計原則](./06-coding-principles.md)
+- [快速開始](./03-quick-start.md)

--- a/docs/agents/05-git-workflow.md
+++ b/docs/agents/05-git-workflow.md
@@ -1,0 +1,91 @@
+# Git 工作流程
+
+> 本文件說明 Git 分支命名與 Commit 訊息規範
+
+## 分支命名規範
+
+### 格式
+
+```
+類別/任務簡述
+```
+
+### 常用前綴
+
+- `feature/` - 新功能開發
+- `bugfix/` - 錯誤修復
+- `hotfix/` - 緊急修復
+- `refactor/` - 程式碼重構
+- `docs/` - 文件更新
+- `test/` - 測試相關
+
+### 命名規則
+
+- ✅ 全小寫
+- ✅ 使用 `-` 分隔單字
+- ✅ 使用 `/` 分層
+- ❌ 避免使用空格或特殊字元
+
+### 範例
+
+```bash
+feature/add-login-page
+bugfix/fix-checkout-error
+refactor/improve-page-objects
+docs/update-readme
+```
+
+## Commit 訊息規範
+
+遵循 **Conventional Commits** 規範。
+
+### 格式
+
+```
+<type>(<scope>): <subject>
+```
+
+### 常用類型
+
+| Type | 說明 | 範例 |
+|------|------|------|
+| `feat` | 新功能 | `feat(auth): add login functionality` |
+| `fix` | 錯誤修復 | `fix(cart): resolve checkout calculation error` |
+| `docs` | 文件更新 | `docs(readme): update installation guide` |
+| `style` | 程式碼格式 | `style: format code with biome` |
+| `refactor` | 重構 | `refactor(pages): simplify page object structure` |
+| `test` | 測試 | `test(api): add product API tests` |
+| `chore` | 雜項 | `chore: update dependencies` |
+
+### 撰寫原則
+
+- ✅ 使用祈使句（如 `add` 而非 `added`）
+- ✅ 第一個字母小寫
+- ✅ 不要在結尾加句號
+- ✅ 簡潔明瞭，說明「做了什麼」而非「為什麼」
+
+### 範例
+
+```bash
+# 好的範例
+feat(login): add remember me checkbox
+fix(api): handle timeout error correctly
+docs(agents): split into modular files
+
+# 避免的範例
+Added login feature  # 非祈使句
+Fix bug.  # 不夠具體
+updated readme  # 缺少 type
+```
+
+## 工作流程建議
+
+1. 從 `main` 分支創建新分支
+2. 進行開發並定期 commit
+3. 推送到遠端並創建 Pull Request
+4. 通過 CI/CD 檢查後合併
+
+## 相關文件
+
+- [開發規範](./04-development-standards.md)
+- [程式設計原則](./06-coding-principles.md)

--- a/docs/agents/06-coding-principles.md
+++ b/docs/agents/06-coding-principles.md
@@ -1,0 +1,173 @@
+# 程式設計原則
+
+> 本文件說明專案的核心程式設計理念與最佳實踐
+
+## 核心原則
+
+### 1. 可讀性優先
+
+程式碼應該易於理解，即使犧牲簡潔性。
+
+**理念**:
+- 程式碼是寫給人看的，其次才是給機器執行
+- 清晰的命名比簡短的命名更重要
+- 適當的註解能幫助理解複雜邏輯
+
+**範例**:
+
+```typescript
+// ✅ 好的做法：清晰易懂
+const isUserEligibleForDiscount = user.age >= 65 || user.isPremiumMember;
+
+// ❌ 避免：過於簡潔但難以理解
+const d = u.a >= 65 || u.p;
+```
+
+### 2. 現代化語法
+
+使用最新的 TypeScript/JavaScript 語法特性。
+
+**優先使用**:
+- `const` 和 `let` 取代 `var`
+- 箭頭函式 `() => {}`
+- 解構賦值 `const { name, age } = user`
+- 可選鏈 `user?.address?.city`
+- 空值合併 `value ?? defaultValue`
+- Template literals `` `Hello ${name}` ``
+
+**範例**:
+
+```typescript
+// ✅ 現代化語法
+const getUserInfo = async (userId: string) => {
+  const user = await fetchUser(userId);
+  return {
+    name: user?.name ?? 'Unknown',
+    email: user?.email ?? 'N/A',
+  };
+};
+
+// ❌ 過時語法
+function getUserInfo(userId) {
+  return fetchUser(userId).then(function(user) {
+    return {
+      name: user && user.name ? user.name : 'Unknown',
+      email: user && user.email ? user.email : 'N/A',
+    };
+  });
+}
+```
+
+### 3. 實務導向
+
+理論正確但實務不適用的方案應避免。
+
+**考量因素**:
+- 維護成本
+- 團隊熟悉度
+- 執行效能
+- 除錯難度
+
+**範例**:
+
+```typescript
+// ✅ 實務導向：直接明瞭
+if (user.role === 'admin' || user.role === 'moderator') {
+  allowAccess();
+}
+
+// ❌ 過度設計：增加複雜度但無實質好處
+const PRIVILEGED_ROLES = new Set(['admin', 'moderator']);
+if (PRIVILEGED_ROLES.has(user.role)) {
+  allowAccess();
+}
+```
+
+## 測試程式碼原則
+
+### Business-Layer 導向
+
+測試應該讀起來像商業流程，而非技術操作。
+
+```typescript
+// ✅ 商業流程導向
+test('使用者可以完成購物流程', async ({ productPage, cartPage }) => {
+  await productPage.addProductToCart('Backpack');
+  await cartPage.proceedToCheckout();
+  await checkoutPage.completeOrder('John', 'Doe', '12345');
+  await checkoutPage.verifyOrderSuccess();
+});
+
+// ❌ 技術操作導向
+test('購物流程', async ({ page }) => {
+  await page.click('[data-test="add-to-cart"]');
+  await page.click('[data-test="checkout"]');
+  await page.fill('#first-name', 'John');
+  await page.fill('#last-name', 'Doe');
+  await page.click('[data-test="continue"]');
+});
+```
+
+### 封裝細節
+
+將技術細節封裝在 Page Objects 或 Helper 函式中。
+
+```typescript
+// ✅ 封裝在 Page Object
+class CheckoutPage {
+  async fillCheckoutInformation(firstName: string, lastName: string, zipCode: string) {
+    await this.page.getByLabel('First Name').fill(firstName);
+    await this.page.getByLabel('Last Name').fill(lastName);
+    await this.page.getByLabel('Zip/Postal Code').fill(zipCode);
+  }
+}
+
+// 測試中使用
+await checkoutPage.fillCheckoutInformation('John', 'Doe', '12345');
+```
+
+## TypeScript 最佳實踐
+
+### 型別安全
+
+- 啟用 `strict` 模式
+- 避免使用 `any`
+- 使用 `noUncheckedIndexedAccess` 確保陣列存取安全
+
+```typescript
+// ✅ 型別安全
+const getFirstItem = <T>(items: T[]): T | undefined => {
+  return items[0]; // TypeScript 知道可能是 undefined
+};
+
+// ❌ 不安全
+const getFirstItem = (items: any[]) => {
+  return items[0]; // 可能導致執行時錯誤
+};
+```
+
+### 介面優於型別別名
+
+對於物件結構，優先使用 `interface`。
+
+```typescript
+// ✅ 使用 interface
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+// ⚠️ 型別別名也可以，但 interface 更適合物件
+type User = {
+  id: string;
+  name: string;
+  email: string;
+};
+```
+
+## 相關文件
+
+- [開發規範](./04-development-standards.md)
+- [測試架構](./08-test-architecture.md)
+- [元素定位策略](./09-locator-strategies.md)

--- a/docs/agents/07-architecture-overview.md
+++ b/docs/agents/07-architecture-overview.md
@@ -1,0 +1,134 @@
+# 架構概覽
+
+> 本文件說明專案的目錄結構與組織方式
+
+## 目錄結構
+
+```
+Playwright/
+├── services/              # 核心服務層
+│   ├── apis/             # API 客戶端
+│   ├── components/       # 可重用 UI 元件
+│   ├── fixtures/         # Playwright Fixtures
+│   ├── pages/            # Page Objects
+│   └── schema/           # API 型別定義
+├── tests/                # 測試案例
+│   ├── api/              # API 測試
+│   │   └── springboot/   # Spring Boot API 測試
+│   └── ui/               # UI 測試
+│       └── saucedemo/    # SauceDemo UI 測試
+├── init-scripts/         # Oracle DB 初始化腳本
+├── scripts/              # 測試執行腳本
+├── docs/                 # 專案文件
+│   └── agents/           # Agent 指引文件
+└── .github/              # CI/CD 配置
+    └── workflows/        # GitHub Actions
+```
+
+## 目錄說明
+
+### services/ - 核心服務層
+
+包含所有可重用的測試基礎設施。
+
+#### apis/
+- `base-api-client.ts` - API 客戶端基礎類別
+- `springboot-api-client.ts` - Spring Boot API 客戶端
+
+#### components/
+- `hamburger-menu.ts` - 漢堡選單元件
+- 其他可重用 UI 元件
+
+#### fixtures/
+- `chain-fixtures.fixture.ts` - 整合所有 Fixtures
+- `page-objects.fixture.ts` - UI 頁面物件 Fixtures
+- `springboot-api-objects.fixture.ts` - API 客戶端 Fixtures
+- `saucedemo-test-data.fixture.ts` - UI 測試資料
+- `springboot-test-data.fixture.ts` - API 測試資料
+
+#### pages/
+- `login-page.ts` - 登入頁面
+- `product-page.ts` - 產品頁面
+- `cart-page.ts` - 購物車頁面
+- `checkout-page.ts` - 結帳頁面
+
+#### schema/
+- `api-types.ts` - 從 Swagger 生成的 API 型別定義
+- `constants.ts` - 常數定義
+
+### tests/ - 測試案例
+
+#### api/springboot/
+- `account.spec.ts` - 帳戶 API 測試
+- `product.spec.ts` - 產品 API 測試
+- `order.spec.ts` - 訂單 API 測試
+
+#### ui/saucedemo/
+- `Login.setup.ts` - 登入狀態設定
+- `Login.spec.ts` - 登入功能測試
+- `Shopping.spec.ts` - 購物流程測試
+- `sanity-test.spec.ts` - 冒煙測試
+
+### init-scripts/ - 資料庫初始化
+
+- `01_setup.sh` - Oracle DB 使用者創建腳本
+
+### scripts/ - 執行腳本
+
+- `test-e2e-ci.ps1` - Windows CI/CD 測試腳本
+- `test-e2e-ci.sh` - Linux/macOS CI/CD 測試腳本
+
+### docs/ - 專案文件
+
+- `agents/` - Agent 指引模組化文件
+- `swagger.json` - API 規格文件
+
+### .github/ - CI/CD 配置
+
+- `workflows/` - GitHub Actions 工作流程定義
+
+## 設計原則
+
+### 分層架構
+
+```
+測試層 (tests/)
+    ↓ 使用
+服務層 (services/)
+    ↓ 封裝
+技術層 (Playwright API)
+```
+
+### 關注點分離
+
+- **測試案例**: 專注於業務邏輯驗證
+- **Page Objects**: 封裝頁面操作
+- **Fixtures**: 管理測試依賴與資料
+- **API Clients**: 封裝 API 呼叫
+
+### 可重用性
+
+- 元件化設計（如 `hamburger-menu.ts`）
+- Fixtures 依賴注入
+- 共用測試資料
+
+## 命名慣例
+
+### 檔案命名
+
+- Page Objects: `{page-name}-page.ts`
+- Fixtures: `{name}.fixture.ts`
+- 測試檔案: `{feature}.spec.ts`
+- Setup 檔案: `{feature}.setup.ts`
+
+### 類別命名
+
+- Page Objects: `{PageName}Page`
+- API Clients: `{ServiceName}ApiClient`
+- Components: `{ComponentName}`
+
+## 相關文件
+
+- [專案概述](./01-project-overview.md)
+- [測試架構](./08-test-architecture.md)
+- [配置指南](./12-configuration-guide.md)

--- a/docs/agents/08-test-architecture.md
+++ b/docs/agents/08-test-architecture.md
@@ -1,0 +1,228 @@
+# 測試架構
+
+> 本文件說明 Custom Fixtures 與 Page Object Model 設計
+
+## Custom Fixtures 架構
+
+本專案使用 Playwright 的 Fixture 系統來管理測試依賴。
+
+### 核心優勢
+
+1. **封裝與可重用性**: 將準備工作與測試內容分離
+2. **依賴注入**: 自動執行初始化邏輯
+3. **按需執行**: 只有測試用到的 Fixture 才會執行（與 `beforeEach` 不同）
+
+### Fixture 類型
+
+#### page-objects.fixture.ts
+封裝 UI 頁面物件，提供：
+- `loginPage` - 登入頁面
+- `productPage` - 產品頁面
+- `cartPage` - 購物車頁面
+- `checkoutPage` - 結帳頁面
+
+#### springboot-api-objects.fixture.ts
+封裝 API 客戶端，提供：
+- `accountApi` - 帳戶 API
+- `productApi` - 產品 API
+- `orderApi` - 訂單 API
+
+#### saucedemo-test-data.fixture.ts
+封裝 UI 測試資料，提供：
+- `standardUserData` - 標準使用者資料
+- `lockedOutUserData` - 鎖定使用者資料
+- `problemUserData` - 問題使用者資料
+
+#### chain-fixtures.fixture.ts
+使用 `mergeTests` 整合所有 Fixtures，提供統一的測試入口。
+
+### 使用範例
+
+```typescript
+import { test, expect } from '../fixtures/chain-fixtures';
+
+test('使用者可以成功登入', async ({ loginPage, standardUserData }) => {
+  // Fixtures 自動注入，無需手動初始化
+  await loginPage.login(standardUserData.username, standardUserData.password);
+  await loginPage.verifyLoginSuccess();
+});
+
+test('可以新增產品到購物車', async ({ productPage, cartPage }) => {
+  await productPage.addProductToCart('Backpack');
+  await cartPage.verifyProductInCart('Backpack');
+});
+```
+
+### Fixture 優勢對比
+
+**使用 Fixture**:
+```typescript
+test('測試', async ({ loginPage, standardUserData }) => {
+  // 直接使用，無需初始化
+  await loginPage.login(standardUserData.username, standardUserData.password);
+});
+```
+
+**不使用 Fixture** (傳統方式):
+```typescript
+test('測試', async ({ page }) => {
+  // 每個測試都要重複初始化
+  const loginPage = new LoginPage(page);
+  const userData = { username: 'standard_user', password: 'secret_sauce' };
+  await loginPage.login(userData.username, userData.password);
+});
+```
+
+## Page Object Model 設計
+
+### 核心原則
+
+1. **封裝低階操作**: 不暴露 Locators 和 `page.click()` 等細節
+2. **商業邏輯導向**: 方法名稱反映使用者行為，而非 UI 操作
+3. **隱藏斷言細節**: 將驗證邏輯封裝進 Page Object
+
+### 設計範例
+
+#### ✅ 好的做法：語意化方法
+
+```typescript
+class CheckoutPage {
+  async fillCheckoutInformation(firstName: string, lastName: string, zipCode: string) {
+    await this.page.getByLabel('First Name').fill(firstName);
+    await this.page.getByLabel('Last Name').fill(lastName);
+    await this.page.getByLabel('Zip/Postal Code').fill(zipCode);
+  }
+
+  async continueCheckout() {
+    await this.page.getByRole('button', { name: 'Continue' }).click();
+  }
+
+  async finishCheckout() {
+    await this.page.getByRole('button', { name: 'Finish' }).click();
+  }
+
+  async verifyOrderCompletion() {
+    await expect(this.page.getByText('Thank you for your order!')).toBeVisible();
+  }
+}
+
+// 測試中使用
+await checkoutPage.fillCheckoutInformation('John', 'Doe', '12345');
+await checkoutPage.continueCheckout();
+await checkoutPage.finishCheckout();
+await checkoutPage.verifyOrderCompletion();
+```
+
+#### ❌ 避免：暴露技術細節
+
+```typescript
+// 不好的做法：在測試中直接操作元素
+await page.getByLabel('First Name').fill('John');
+await page.getByLabel('Last Name').fill('Doe');
+await page.getByLabel('Zip/Postal Code').fill('12345');
+await page.getByRole('button', { name: 'Continue' }).click();
+await page.getByRole('button', { name: 'Finish' }).click();
+await expect(page.getByText('Thank you for your order!')).toBeVisible();
+```
+
+### Page Object 結構
+
+```typescript
+export class ProductPage {
+  constructor(private readonly page: Page) {}
+
+  // 私有方法：封裝元素定位
+  private getAddToCartButton(productName: string) {
+    return this.page.getByRole('button', { name: `Add ${productName} to cart` });
+  }
+
+  // 公開方法：提供商業邏輯操作
+  async addProductToCart(productName: string) {
+    await this.getAddToCartButton(productName).click();
+  }
+
+  // 驗證方法：封裝斷言邏輯
+  async verifyProductAdded(productName: string) {
+    const button = this.getAddToCartButton(productName);
+    await expect(button).toHaveText('Remove');
+  }
+}
+```
+
+### 方法命名規範
+
+| 操作類型 | 命名模式 | 範例 |
+|---------|---------|------|
+| 導航 | `navigateTo{Page}` | `navigateToCart()` |
+| 填寫 | `fill{Field}` | `fillCheckoutInformation()` |
+| 點擊 | `click{Element}` 或動詞 | `continueCheckout()` |
+| 驗證 | `verify{Condition}` | `verifyOrderCompletion()` |
+| 取得 | `get{Data}` | `getProductPrice()` |
+
+## 元件化設計
+
+對於重複出現的 UI 元件，創建獨立的元件類別。
+
+### 範例：漢堡選單元件
+
+```typescript
+export class HamburgerMenu {
+  constructor(private readonly page: Page) {}
+
+  async open() {
+    await this.page.getByRole('button', { name: 'Open Menu' }).click();
+  }
+
+  async logout() {
+    await this.open();
+    await this.page.getByRole('link', { name: 'Logout' }).click();
+  }
+}
+
+// 在 Page Object 中使用
+class ProductPage {
+  private hamburgerMenu: HamburgerMenu;
+
+  constructor(private readonly page: Page) {
+    this.hamburgerMenu = new HamburgerMenu(page);
+  }
+
+  async logout() {
+    await this.hamburgerMenu.logout();
+  }
+}
+```
+
+## 測試資料管理
+
+### 使用 Fixture 管理測試資料
+
+```typescript
+// saucedemo-test-data.fixture.ts
+export const saucedemoTestDataFixture = base.extend<SaucedemoTestData>({
+  standardUserData: async ({}, use) => {
+    await use({
+      username: 'standard_user',
+      password: 'secret_sauce',
+    });
+  },
+});
+
+// 測試中使用
+test('登入測試', async ({ loginPage, standardUserData }) => {
+  await loginPage.login(standardUserData.username, standardUserData.password);
+});
+```
+
+### 優點
+
+- ✅ 集中管理測試資料
+- ✅ 易於維護和更新
+- ✅ 避免硬編碼
+- ✅ 支援多環境配置
+
+## 相關文件
+
+- [架構概覽](./07-architecture-overview.md)
+- [元素定位策略](./09-locator-strategies.md)
+- [程式設計原則](./06-coding-principles.md)

--- a/docs/agents/09-locator-strategies.md
+++ b/docs/agents/09-locator-strategies.md
@@ -1,0 +1,285 @@
+# 元素定位策略
+
+> 本文件說明 Playwright 元素定位的最佳實踐
+
+## 定位器優先順序
+
+按照穩健性和可維護性排序（由高到低）：
+
+### 1. getByRole (最推薦)
+
+最穩健的定位方式，符合無障礙設計原則。
+
+```typescript
+// 按鈕
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// 連結
+await page.getByRole('link', { name: 'Home' }).click();
+
+// 文字輸入框
+await page.getByRole('textbox', { name: 'Username' }).fill('user123');
+
+// 複選框
+await page.getByRole('checkbox', { name: 'Remember me' }).check();
+```
+
+**優點**:
+- ✅ 最穩健，不受 DOM 結構變化影響
+- ✅ 符合無障礙設計（ARIA）
+- ✅ 語意清晰，易於理解
+- ✅ 自動處理多語言（透過 ARIA label）
+
+**常用 Role**:
+- `button` - 按鈕
+- `link` - 連結
+- `textbox` - 文字輸入框
+- `checkbox` - 複選框
+- `radio` - 單選按鈕
+- `heading` - 標題
+- `list` - 列表
+- `listitem` - 列表項目
+
+### 2. getByText
+
+透過顯示文字定位元素。
+
+```typescript
+// 精確匹配
+await page.getByText('Welcome back!').click();
+
+// 部分匹配
+await page.getByText('Welcome', { exact: false }).click();
+
+// 使用正則表達式
+await page.getByText(/welcome/i).click();
+```
+
+**適用情境**:
+- 靜態文字內容
+- 標籤或標題
+- 確認訊息
+
+**注意事項**:
+- ⚠️ 文字變更會導致測試失敗
+- ⚠️ 多語言環境需要特別處理
+
+### 3. getByLabel
+
+適用於表單輸入欄位。
+
+```typescript
+// 透過 label 定位
+await page.getByLabel('Email address').fill('user@example.com');
+await page.getByLabel('Password').fill('secret123');
+
+// 支援部分匹配
+await page.getByLabel('Email', { exact: false }).fill('user@example.com');
+```
+
+**優點**:
+- ✅ 語意清晰
+- ✅ 符合無障礙設計
+- ✅ 適合表單測試
+
+### 4. getByPlaceholder
+
+當沒有 label 時使用。
+
+```typescript
+await page.getByPlaceholder('Enter your email').fill('user@example.com');
+await page.getByPlaceholder('Search...').fill('product name');
+```
+
+**適用情境**:
+- 搜尋框
+- 沒有明確 label 的輸入框
+
+### 5. getByTestId (最後選擇)
+
+使用 `data-testid` 屬性定位。
+
+```typescript
+await page.getByTestId('submit-button').click();
+await page.getByTestId('user-profile').click();
+```
+
+**使用時機**:
+- 其他定位器都不適用時
+- 需要穩定的定位器但元素沒有語意化屬性
+
+**缺點**:
+- ❌ 需要修改 HTML 添加測試屬性
+- ❌ 不符合無障礙設計原則
+
+## 使用 Chrome DevTools 查看 Accessibility
+
+### 步驟
+
+1. 開啟 Chrome DevTools (F12)
+2. 切換到 **Elements** 面板
+3. 選擇要檢查的元素
+4. 在右側面板切換到 **Accessibility** 標籤
+5. 查看 **Role** 和 **Name** 屬性
+
+### 範例
+
+```html
+<button aria-label="Add to cart">
+  <svg>...</svg>
+</button>
+```
+
+**Accessibility 面板顯示**:
+- Role: `button`
+- Name: `Add to cart`
+
+**對應的定位器**:
+```typescript
+await page.getByRole('button', { name: 'Add to cart' }).click();
+```
+
+## 定位器組合
+
+### 鏈式定位
+
+```typescript
+// 在特定容器內定位
+await page
+  .getByRole('article')
+  .filter({ hasText: 'Product 1' })
+  .getByRole('button', { name: 'Add to cart' })
+  .click();
+```
+
+### 使用 locator
+
+```typescript
+// 定義可重用的定位器
+const productCard = page.locator('[data-testid="product-card"]').first();
+await productCard.getByRole('button', { name: 'Add to cart' }).click();
+```
+
+## 避免的定位方式
+
+### ❌ CSS Selector (不推薦)
+
+```typescript
+// 脆弱，容易因 DOM 變化而失效
+await page.locator('.btn-primary').click();
+await page.locator('#submit-btn').click();
+```
+
+### ❌ XPath (不推薦)
+
+```typescript
+// 難以閱讀和維護
+await page.locator('//button[@class="btn-primary"]').click();
+```
+
+### ❌ 依賴 DOM 結構 (不推薦)
+
+```typescript
+// 脆弱，DOM 結構變化會失效
+await page.locator('div > div > button').click();
+```
+
+## 最佳實踐
+
+### 1. 優先使用語意化定位器
+
+```typescript
+// ✅ 好的做法
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// ❌ 避免
+await page.locator('[data-testid="submit-btn"]').click();
+```
+
+### 2. 使用有意義的 name 參數
+
+```typescript
+// ✅ 清晰明確
+await page.getByRole('button', { name: 'Add to cart' }).click();
+
+// ❌ 模糊不清
+await page.getByRole('button').first().click();
+```
+
+### 3. 封裝定位邏輯到 Page Object
+
+```typescript
+class ProductPage {
+  // 私有方法封裝定位器
+  private getAddToCartButton(productName: string) {
+    return this.page.getByRole('button', { name: `Add ${productName} to cart` });
+  }
+
+  // 公開方法提供操作
+  async addProductToCart(productName: string) {
+    await this.getAddToCartButton(productName).click();
+  }
+}
+```
+
+### 4. 處理動態內容
+
+```typescript
+// 使用正則表達式
+await page.getByText(/Product \d+/).click();
+
+// 使用 filter
+await page
+  .getByRole('listitem')
+  .filter({ hasText: 'Available' })
+  .first()
+  .click();
+```
+
+### 5. 等待元素狀態
+
+```typescript
+// 等待可見
+await page.getByRole('button', { name: 'Submit' }).waitFor({ state: 'visible' });
+
+// 等待啟用
+await page.getByRole('button', { name: 'Submit' }).waitFor({ state: 'enabled' });
+```
+
+## 常見問題
+
+### Q: 如何定位沒有文字的按鈕？
+
+```typescript
+// 使用 aria-label
+await page.getByRole('button', { name: 'Close' }).click();
+
+// 或使用 title 屬性
+await page.getByTitle('Close dialog').click();
+```
+
+### Q: 如何處理重複的元素？
+
+```typescript
+// 使用 filter 縮小範圍
+await page
+  .getByRole('button', { name: 'Delete' })
+  .filter({ hasText: 'Product 1' })
+  .click();
+
+// 或使用 nth
+await page.getByRole('button', { name: 'Delete' }).nth(0).click();
+```
+
+### Q: 如何定位 Shadow DOM 內的元素？
+
+```typescript
+// Playwright 自動穿透 Shadow DOM
+await page.getByRole('button', { name: 'Submit' }).click();
+```
+
+## 相關文件
+
+- [測試架構](./08-test-architecture.md)
+- [程式設計原則](./06-coding-principles.md)
+- [Playwright Locators 官方文件](https://playwright.dev/docs/locators)

--- a/docs/agents/10-testing-strategies.md
+++ b/docs/agents/10-testing-strategies.md
@@ -1,0 +1,266 @@
+# 測試策略
+
+> 本文件說明資料清理策略與全域登入狀態管理
+
+## 資料清理策略
+
+本專案採用 **容器重啟策略** 確保測試隔離性。
+
+### 工作原理
+
+1. 每次測試前停止並刪除所有容器和 volumes
+2. 重新啟動 Docker Compose 環境
+3. Spring Boot 自動執行 Flyway migrate
+4. 等待健康檢查通過後執行測試
+
+### 實作方式
+
+#### Windows (PowerShell)
+
+```powershell
+# 停止並刪除容器
+podman compose -f docker-compose.test.yml down -v
+
+# 啟動新環境
+podman compose -f docker-compose.test.yml up -d
+
+# 等待健康檢查
+Start-Sleep -Seconds 30
+
+# 執行測試
+pnpm playwright test --project=api-e2e
+```
+
+#### Linux/macOS (Bash)
+
+```bash
+# 停止並刪除容器
+podman compose -f docker-compose.test.yml down -v
+
+# 啟動新環境
+podman compose -f docker-compose.test.yml up -d
+
+# 等待健康檢查
+sleep 30
+
+# 執行測試
+pnpm playwright test --project=api-e2e
+```
+
+### 優點
+
+- ✅ **完全隔離**: 每次都是全新環境，無殘留資料
+- ✅ **簡單可靠**: 不依賴額外工具（如 Flyway CLI）
+- ✅ **適合 CI/CD**: 容易整合到自動化流程
+- ✅ **可重複性**: 測試結果穩定且可預測
+
+### 缺點
+
+- ⏱️ **啟動時間較長**: Oracle DB 需要 1-2 分鐘啟動
+- 💾 **資源消耗**: 每次都要重新初始化資料庫
+
+### 適用情境
+
+- ✅ E2E 測試
+- ✅ 整合測試
+- ✅ CI/CD Pipeline
+- ❌ 單元測試（過於重量級）
+
+### 詳細說明
+
+完整的策略分析請參考：[E2E-TESTING-CLEANUP-STRATEGY.md](../../E2E-TESTING-CLEANUP-STRATEGY.md)
+
+## 全域登入狀態分享
+
+使用 `storageState` 避免每個測試重複登入，提升測試效率。
+
+### 工作原理
+
+1. **Setup 測試**執行登入並儲存狀態
+2. **主測試**設定依賴關係
+3. Playwright 自動注入登入狀態到所有測試
+
+### 配置方式
+
+#### playwright.config.ts
+
+```typescript
+export default defineConfig({
+  projects: [
+    // Setup 專案：執行登入並儲存狀態
+    {
+      name: 'ui-setup',
+      testMatch: '**/saucedemo/*.setup.ts',
+      use: {
+        storageState: 'playwright/.auth/user.json',
+      },
+    },
+    // 主測試專案：使用儲存的登入狀態
+    {
+      name: 'ui-staging',
+      testMatch: '**/saucedemo/*.spec.ts',
+      dependencies: ['ui-setup'], // 依賴 Setup
+      use: {
+        storageState: 'playwright/.auth/user.json',
+      },
+    },
+  ],
+});
+```
+
+### Setup 測試範例
+
+```typescript
+// tests/ui/saucedemo/Login.setup.ts
+import { test as setup } from '@playwright/test';
+
+setup('登入並儲存狀態', async ({ page }) => {
+  // 執行登入
+  await page.goto('https://www.saucedemo.com/');
+  await page.getByLabel('Username').fill('standard_user');
+  await page.getByLabel('Password').fill('secret_sauce');
+  await page.getByRole('button', { name: 'Login' }).click();
+
+  // 等待登入完成
+  await page.waitForURL('**/inventory.html');
+
+  // 狀態會自動儲存到 storageState 指定的路徑
+});
+```
+
+### 主測試使用
+
+```typescript
+// tests/ui/saucedemo/Shopping.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('可以新增產品到購物車', async ({ page }) => {
+  // 已經是登入狀態，直接開始測試
+  await page.goto('https://www.saucedemo.com/inventory.html');
+  
+  await page.getByRole('button', { name: 'Add to cart' }).first().click();
+  
+  const cartBadge = page.locator('.shopping_cart_badge');
+  await expect(cartBadge).toHaveText('1');
+});
+```
+
+### 優點
+
+- ✅ **效率提升**: 避免每個測試重複登入
+- ✅ **測試隔離**: 每個測試仍然獨立執行
+- ✅ **易於維護**: 登入邏輯集中管理
+- ✅ **支援多使用者**: 可以為不同角色創建不同的 Setup
+
+### 多使用者範例
+
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  projects: [
+    // 標準使用者 Setup
+    {
+      name: 'ui-setup-standard',
+      testMatch: '**/setup/standard-user.setup.ts',
+      use: {
+        storageState: 'playwright/.auth/standard-user.json',
+      },
+    },
+    // 管理員 Setup
+    {
+      name: 'ui-setup-admin',
+      testMatch: '**/setup/admin-user.setup.ts',
+      use: {
+        storageState: 'playwright/.auth/admin-user.json',
+      },
+    },
+    // 標準使用者測試
+    {
+      name: 'ui-standard-user',
+      testMatch: '**/tests/standard-user/*.spec.ts',
+      dependencies: ['ui-setup-standard'],
+      use: {
+        storageState: 'playwright/.auth/standard-user.json',
+      },
+    },
+    // 管理員測試
+    {
+      name: 'ui-admin',
+      testMatch: '**/tests/admin/*.spec.ts',
+      dependencies: ['ui-setup-admin'],
+      use: {
+        storageState: 'playwright/.auth/admin-user.json',
+      },
+    },
+  ],
+});
+```
+
+## 測試執行策略
+
+### 本地開發
+
+```bash
+# 執行特定測試
+pnpm playwright test Shopping.spec.ts
+
+# 執行特定專案
+pnpm playwright test --project=ui-staging
+
+# Debug 模式
+pnpm playwright test --debug
+```
+
+### CI/CD 環境
+
+```bash
+# 完整測試流程（含容器重啟）
+pnpm run test:e2e:ci
+
+# 或使用腳本
+.\scripts\test-e2e-ci.ps1  # Windows
+bash scripts/test-e2e-ci.sh  # Linux/macOS
+```
+
+## 測試組織
+
+### 按功能分組
+
+```
+tests/
+├── ui/
+│   └── saucedemo/
+│       ├── Login.setup.ts      # Setup
+│       ├── Login.spec.ts       # 登入測試
+│       ├── Shopping.spec.ts    # 購物測試
+│       └── Checkout.spec.ts    # 結帳測試
+└── api/
+    └── springboot/
+        ├── account.spec.ts     # 帳戶 API
+        ├── product.spec.ts     # 產品 API
+        └── order.spec.ts       # 訂單 API
+```
+
+### 使用標籤
+
+```typescript
+// 標記為冒煙測試
+test('基本功能檢查', { tag: '@smoke' }, async ({ page }) => {
+  // ...
+});
+
+// 標記為回歸測試
+test('完整購物流程', { tag: '@regression' }, async ({ page }) => {
+  // ...
+});
+
+// 執行特定標籤的測試
+// pnpm playwright test --grep @smoke
+```
+
+## 相關文件
+
+- [快速開始](./03-quick-start.md)
+- [CI/CD 整合](./11-cicd-integration.md)
+- [配置指南](./12-configuration-guide.md)
+- [E2E 測試清理策略](../../E2E-TESTING-CLEANUP-STRATEGY.md)

--- a/docs/agents/11-cicd-integration.md
+++ b/docs/agents/11-cicd-integration.md
@@ -1,0 +1,349 @@
+# CI/CD 整合
+
+> 本文件說明 GitHub Actions 與 Docker Compose 配置
+
+## GitHub Actions 配置
+
+本專案使用 GitHub Actions 進行自動化測試。
+
+### 關鍵特點
+
+#### 容器化執行
+
+- 使用官方 Playwright Docker 映像檔 (`mcr.microsoft.com/playwright:v1.57.0`)
+- 預先安裝瀏覽器，省去下載時間
+- 確保環境一致性
+
+#### 觸發條件
+
+```yaml
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:  # 手動觸發
+  repository_dispatch:  # 後端專案觸發
+    types: [trigger-e2e-tests]
+```
+
+#### 環境變數管理
+
+使用 GitHub Secrets 儲存敏感資訊：
+
+```yaml
+env:
+  DB_USER: ${{ secrets.DB_USER }}
+  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+  ORACLE_TEST_USERNAME: ${{ secrets.DB_USER }}
+  ORACLE_TEST_PASSWORD: ${{ secrets.DB_PASSWORD }}
+```
+
+**必要的 Secrets**:
+- `DB_USER`: 資料庫使用者名稱
+- `DB_PASSWORD`: 資料庫密碼
+- `GHCR_TOKEN`: GitHub Container Registry 存取權杖
+
+### 工作流程步驟
+
+#### 1. 登入 GHCR
+
+```yaml
+- name: Log in to GitHub Container Registry
+  run: echo "${{ secrets.GHCR_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+```
+
+#### 2. 啟動測試環境
+
+```yaml
+- name: Start test environment
+  run: |
+    podman compose -f docker-compose.test.yml up -d
+    sleep 30  # 等待服務啟動
+```
+
+#### 3. 等待健康檢查
+
+```yaml
+- name: Wait for services to be healthy
+  run: |
+    timeout 300 bash -c 'until podman exec oracle-db-test healthcheck.sh; do sleep 5; done'
+    timeout 300 bash -c 'until curl -f http://localhost:8787/actuator/health; do sleep 5; done'
+```
+
+#### 4. 執行測試
+
+```yaml
+- name: Run Playwright tests
+  run: pnpm playwright test --project=api-e2e
+```
+
+#### 5. 上傳測試報告
+
+```yaml
+- name: Upload test report
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: playwright-report
+    path: playwright-report/
+    retention-days: 30
+```
+
+### 完整範例
+
+```yaml
+name: E2E Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0
+    
+    env:
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      
+      - name: Install dependencies
+        run: pnpm install
+      
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GHCR_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+      
+      - name: Start test environment
+        run: podman compose -f docker-compose.test.yml up -d
+      
+      - name: Wait for services
+        run: |
+          timeout 300 bash -c 'until curl -f http://localhost:8787/actuator/health; do sleep 5; done'
+      
+      - name: Run tests
+        run: pnpm playwright test --project=api-e2e
+      
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+```
+
+## Docker Compose 配置
+
+### 服務架構
+
+```yaml
+services:
+  app:
+    image: ghcr.io/your-org/spring-boot-app:latest
+    ports:
+      - "8787:8787"
+    depends_on:
+      oracle-db:
+        condition: service_healthy
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:oracle:thin:@oracle-db:1521/FREEPDB1
+      - SPRING_DATASOURCE_USERNAME=${ORACLE_TEST_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${ORACLE_TEST_PASSWORD}
+
+  oracle-db:
+    image: container-registry.oracle.com/database/free:latest
+    ports:
+      - "1521:1521"
+    environment:
+      - ORACLE_PWD=${ORACLE_TEST_PASSWORD}
+    volumes:
+      - ./init-scripts:/opt/oracle/scripts/startup
+    healthcheck:
+      test: ["CMD", "healthcheck.sh"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+```
+
+### 環境變數配置
+
+#### Spring Boot 應用
+
+```yaml
+environment:
+  - SPRING_DATASOURCE_URL=jdbc:oracle:thin:@oracle-db:1521/FREEPDB1
+  - SPRING_DATASOURCE_USERNAME=${ORACLE_TEST_USERNAME}
+  - SPRING_DATASOURCE_PASSWORD=${ORACLE_TEST_PASSWORD}
+  - SPRING_JPA_HIBERNATE_DDL_AUTO=none
+  - SPRING_FLYWAY_ENABLED=true
+```
+
+#### Oracle Database
+
+```yaml
+environment:
+  - ORACLE_PWD=${ORACLE_TEST_PASSWORD}
+  - ORACLE_CHARACTERSET=AL32UTF8
+```
+
+### 健康檢查
+
+#### Oracle DB 健康檢查
+
+```yaml
+healthcheck:
+  test: |
+    bash -c "echo 'SELECT 1 FROM DUAL;' | 
+    sqlplus -s sys/${ORACLE_TEST_PASSWORD}@//localhost:1521/FREEPDB1 as sysdba"
+  interval: 10s
+  timeout: 5s
+  retries: 30
+  start_period: 60s
+```
+
+**檢查邏輯**:
+- 使用 SYS 使用者連接
+- 檢查 PDB 是否處於 READ WRITE 模式
+- 避免時序問題（等待 PDB 完全啟動）
+
+#### Spring Boot 健康檢查
+
+```yaml
+healthcheck:
+  test: ["CMD", "curl", "-f", "http://localhost:8787/actuator/health"]
+  interval: 10s
+  timeout: 5s
+  retries: 10
+  start_period: 30s
+```
+
+### 初始化流程
+
+1. **Oracle DB 啟動**
+   - 容器啟動
+   - 執行 `init-scripts/01_setup.sh`
+   - 創建測試使用者和權限
+
+2. **Spring Boot 啟動**
+   - 等待 Oracle DB 健康檢查通過
+   - 連接資料庫
+   - 執行 Flyway migrate
+   - 應用程式就緒
+
+3. **測試執行**
+   - 等待所有服務健康檢查通過
+   - 執行 Playwright 測試
+
+### 初始化腳本範例
+
+```bash
+#!/bin/bash
+# init-scripts/01_setup.sh
+
+sqlplus -s sys/${ORACLE_PWD}@//localhost:1521/FREEPDB1 as sysdba <<EOF
+  -- 創建測試使用者
+  CREATE USER ${ORACLE_TEST_USERNAME} IDENTIFIED BY ${ORACLE_TEST_PASSWORD};
+  
+  -- 授予權限
+  GRANT CONNECT, RESOURCE TO ${ORACLE_TEST_USERNAME};
+  GRANT CREATE SESSION TO ${ORACLE_TEST_USERNAME};
+  GRANT CREATE TABLE TO ${ORACLE_TEST_USERNAME};
+  GRANT CREATE SEQUENCE TO ${ORACLE_TEST_USERNAME};
+  GRANT UNLIMITED TABLESPACE TO ${ORACLE_TEST_USERNAME};
+  
+  EXIT;
+EOF
+```
+
+## CI/CD 策略差異
+
+### 本地開發 vs CI 環境
+
+| 設定項目 | CI 環境 | 本機開發 |
+|---------|---------|----------|
+| Retries | 2 次 | 0 次 |
+| Workers | 2 | 3 |
+| Reporter | List + HTML | List + HTML (時間戳記) |
+| Video | Retain on Failure | Off |
+| Trace | Retain on Failure | Off |
+| 容器重啟 | 每次執行 | 手動控制 |
+
+### 配置範例
+
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : 3,
+  reporter: process.env.CI
+    ? [['list'], ['html']]
+    : [['list'], ['html', { outputFolder: `playwright-report/${timestamp}` }]],
+  use: {
+    trace: process.env.CI ? 'retain-on-failure' : 'off',
+    video: process.env.CI ? 'retain-on-failure' : 'off',
+  },
+});
+```
+
+## 疑難排解
+
+### 容器啟動失敗
+
+```bash
+# 檢查容器狀態
+podman ps -a
+
+# 查看容器日誌
+podman logs spring-boot-app-test
+podman logs oracle-db-test
+
+# 重新啟動
+podman compose -f docker-compose.test.yml down -v
+podman compose -f docker-compose.test.yml up -d
+```
+
+### 健康檢查超時
+
+```yaml
+# 增加等待時間
+healthcheck:
+  retries: 50  # 從 30 增加到 50
+  start_period: 120s  # 從 60s 增加到 120s
+```
+
+### 測試連線失敗
+
+```bash
+# 確認服務正在運行
+curl http://localhost:8787/actuator/health
+
+# 檢查網路連接
+podman network inspect bridge
+```
+
+## 相關文件
+
+- [測試策略](./10-testing-strategies.md)
+- [快速開始](./03-quick-start.md)
+- [疑難排解](./14-troubleshooting.md)
+- [GitHub Actions 文件](https://docs.github.com/en/actions)
+- [Docker Compose 文件](https://docs.docker.com/compose/)

--- a/docs/agents/12-configuration-guide.md
+++ b/docs/agents/12-configuration-guide.md
@@ -1,0 +1,393 @@
+# 配置指南
+
+> 本文件說明 Playwright 與 TypeScript 配置檔案
+
+## playwright.config.ts
+
+Playwright 測試框架的核心配置檔案。
+
+### 動態報告路徑
+
+根據執行環境自動調整報告路徑：
+
+```typescript
+const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
+
+export default defineConfig({
+  reporter: process.env.CI
+    ? [['list'], ['html']]  // CI: 固定路徑
+    : [['list'], ['html', { outputFolder: `playwright-report/${timestamp}` }]],  // 本地: 時間戳記
+});
+```
+
+**路徑範例**:
+- **本地開發**: `playwright-report/2024-05-20T14-30-00/`
+- **CI 環境**: `playwright-report/`
+
+### CI/CD 策略差異
+
+根據環境自動調整測試策略：
+
+```typescript
+export default defineConfig({
+  // 重試次數
+  retries: process.env.CI ? 2 : 0,
+  
+  // 並行執行數
+  workers: process.env.CI ? 2 : 3,
+  
+  // 測試超時
+  timeout: 30 * 1000,
+  
+  // 全域設定
+  use: {
+    // 截圖
+    screenshot: process.env.CI ? 'only-on-failure' : 'off',
+    
+    // 錄影
+    video: process.env.CI ? 'retain-on-failure' : 'off',
+    
+    // Trace
+    trace: process.env.CI ? 'retain-on-failure' : 'off',
+    
+    // 基礎 URL
+    baseURL: 'http://localhost:8787',
+  },
+});
+```
+
+**策略對照表**:
+
+| 設定項目 | CI 環境 | 本機開發 | 說明 |
+|---------|---------|----------|------|
+| Retries | 2 次 | 0 次 | CI 環境允許重試以應對網路不穩定 |
+| Workers | 2 | 3 | CI 環境資源有限，減少並行數 |
+| Reporter | List + HTML | List + HTML (時間戳記) | 本地保留歷史報告 |
+| Screenshot | On Failure | Off | CI 需要截圖協助除錯 |
+| Video | Retain on Failure | Off | CI 保留失敗測試的錄影 |
+| Trace | Retain on Failure | Off | CI 保留詳細的執行追蹤 |
+
+### 專案配置
+
+定義多個測試專案與依賴關係：
+
+```typescript
+export default defineConfig({
+  projects: [
+    // UI Setup 專案
+    {
+      name: 'ui-setup',
+      testMatch: '**/saucedemo/*.setup.ts',
+      use: {
+        storageState: 'playwright/.auth/user.json',
+      },
+    },
+    
+    // UI 測試專案（依賴 Setup）
+    {
+      name: 'ui-staging',
+      testMatch: '**/saucedemo/*.spec.ts',
+      dependencies: ['ui-setup'],  // 先執行 Setup
+      use: {
+        storageState: 'playwright/.auth/user.json',
+        baseURL: 'https://www.saucedemo.com',
+      },
+    },
+    
+    // API 測試專案
+    {
+      name: 'api-e2e',
+      testMatch: '**/api/springboot/*.spec.ts',
+      use: {
+        baseURL: 'http://localhost:8787',
+      },
+    },
+  ],
+});
+```
+
+**專案類型**:
+- `ui-setup`: 執行登入並儲存狀態
+- `ui-staging`: UI 測試（使用儲存的登入狀態）
+- `api-e2e`: API 測試
+
+### 瀏覽器配置
+
+```typescript
+export default defineConfig({
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    // 行動裝置
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+});
+```
+
+### 完整配置範例
+
+```typescript
+import { defineConfig, devices } from '@playwright/test';
+
+const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : 3,
+  
+  reporter: process.env.CI
+    ? [['list'], ['html']]
+    : [['list'], ['html', { outputFolder: `playwright-report/${timestamp}` }]],
+  
+  use: {
+    baseURL: 'http://localhost:8787',
+    trace: process.env.CI ? 'retain-on-failure' : 'off',
+    video: process.env.CI ? 'retain-on-failure' : 'off',
+    screenshot: process.env.CI ? 'only-on-failure' : 'off',
+  },
+  
+  projects: [
+    {
+      name: 'ui-setup',
+      testMatch: '**/saucedemo/*.setup.ts',
+      use: {
+        storageState: 'playwright/.auth/user.json',
+      },
+    },
+    {
+      name: 'ui-staging',
+      testMatch: '**/saucedemo/*.spec.ts',
+      dependencies: ['ui-setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+        baseURL: 'https://www.saucedemo.com',
+      },
+    },
+    {
+      name: 'api-e2e',
+      testMatch: '**/api/springboot/*.spec.ts',
+      use: {
+        baseURL: 'http://localhost:8787',
+      },
+    },
+  ],
+});
+```
+
+## tsconfig.json
+
+TypeScript 編譯器配置，使用現代化設定。
+
+### 核心配置
+
+```json
+{
+  "compilerOptions": {
+    // 模組系統
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    
+    // 目標版本
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    
+    // 型別檢查
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    
+    // 輸出
+    "outDir": "./dist",
+    "rootDir": "./",
+    
+    // 其他
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "tests/**/*",
+    "services/**/*",
+    "global-setup.ts",
+    "playwright.config.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}
+```
+
+### 重要設定說明
+
+#### module: "esnext"
+- 使用最新的 ES 模組語法
+- 支援 `import` / `export`
+- 與 Playwright 完美整合
+
+#### moduleResolution: "bundler"
+- 現代模組解析策略
+- 支援 package.json 的 `exports` 欄位
+- 更好的型別推斷
+
+#### strict: true
+啟用所有嚴格型別檢查：
+- `noImplicitAny`: 禁止隱式 `any`
+- `strictNullChecks`: 嚴格的 null 檢查
+- `strictFunctionTypes`: 嚴格的函式型別檢查
+- `strictBindCallApply`: 嚴格的 bind/call/apply 檢查
+
+#### noUncheckedIndexedAccess: true
+確保陣列存取安全：
+
+```typescript
+// 啟用後
+const items: string[] = ['a', 'b', 'c'];
+const first = items[0];  // 型別: string | undefined
+
+// 未啟用
+const first = items[0];  // 型別: string (不安全)
+```
+
+### 路徑別名
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@services/*": ["services/*"],
+      "@tests/*": ["tests/*"],
+      "@fixtures/*": ["services/fixtures/*"]
+    }
+  }
+}
+```
+
+**使用範例**:
+```typescript
+// 使用別名
+import { LoginPage } from '@services/pages/login-page';
+import { test } from '@fixtures/chain-fixtures';
+
+// 不使用別名
+import { LoginPage } from '../../services/pages/login-page';
+import { test } from '../../services/fixtures/chain-fixtures';
+```
+
+## package.json
+
+專案依賴與腳本配置。
+
+### 重要腳本
+
+```json
+{
+  "scripts": {
+    // 測試執行
+    "test:e2e": "playwright test --project=api-e2e",
+    "test:e2e:ci": "pwsh -File ./scripts/test-e2e-ci.ps1",
+    "test:ui": "playwright test --project=ui-staging",
+    
+    // 容器管理
+    "compose-up": "podman compose -f docker-compose.test.yml up -d",
+    "compose-down": "podman compose -f docker-compose.test.yml down -v",
+    "compose-restart": "pnpm run compose-down && pnpm run compose-up",
+    
+    // 程式碼品質
+    "biome:check": "biome check .",
+    "biome:fix": "biome check --write .",
+    
+    // API 型別生成
+    "api-spec:update": "openapi-typescript http://localhost:8787/v3/api-docs -o services/schema/api-types.ts"
+  }
+}
+```
+
+### 依賴版本
+
+```json
+{
+  "devDependencies": {
+    "@playwright/test": "^1.57.0",
+    "@biomejs/biome": "^1.9.4",
+    "typescript": "^5.7.2",
+    "openapi-typescript": "^7.4.4"
+  }
+}
+```
+
+## .env 配置
+
+環境變數配置檔案。
+
+### 範例
+
+```bash
+# Oracle Database
+ORACLE_TEST_USERNAME=testuser
+ORACLE_TEST_PASSWORD=testpass123
+
+# Spring Boot
+SPRING_DATASOURCE_URL=jdbc:oracle:thin:@localhost:1521/FREEPDB1
+SPRING_DATASOURCE_USERNAME=testuser
+SPRING_DATASOURCE_PASSWORD=testpass123
+```
+
+### 使用方式
+
+```typescript
+// 在測試中使用
+const dbUser = process.env.ORACLE_TEST_USERNAME;
+const dbPassword = process.env.ORACLE_TEST_PASSWORD;
+```
+
+## biome.json
+
+程式碼格式化與 Linting 配置。
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  }
+}
+```
+
+## 相關文件
+
+- [專案概述](./01-project-overview.md)
+- [架構概覽](./07-architecture-overview.md)
+- [測試策略](./10-testing-strategies.md)
+- [Playwright 配置文件](https://playwright.dev/docs/test-configuration)
+- [TypeScript 配置文件](https://www.typescriptlang.org/tsconfig)

--- a/docs/agents/13-advanced-techniques.md
+++ b/docs/agents/13-advanced-techniques.md
@@ -1,0 +1,403 @@
+# 進階技巧
+
+> 本文件說明 Playwright 的進階功能與實用技巧
+
+## API 型別安全
+
+使用 `openapi-typescript` 從 Swagger 自動生成型別定義，確保 API 呼叫的型別安全。
+
+### 生成型別定義
+
+```bash
+pnpm run api-spec:update
+```
+
+這個指令會：
+1. 從 `http://localhost:8787/v3/api-docs` 取得 Swagger 規格
+2. 生成 TypeScript 型別定義
+3. 儲存到 `services/schema/api-types.ts`
+
+### 使用範例
+
+```typescript
+import type { paths } from '@/services/schema/api-types';
+
+// 定義 API 回應型別
+type GetProductsResponse = paths['/api/products']['get']['responses']['200']['content']['application/json'];
+
+// 在 API 客戶端中使用
+class ProductApiClient {
+  async getProducts(): Promise<GetProductsResponse> {
+    const response = await this.request.get('/api/products');
+    return response.json();
+  }
+}
+```
+
+### 優點
+
+- ✅ **型別安全**: 編譯時期檢查 API 呼叫
+- ✅ **自動完成**: IDE 提供完整的自動完成
+- ✅ **重構友善**: 型別變更時自動提示
+- ✅ **文件同步**: 確保程式碼與 API 規格一致
+
+## 網路攔截與 Mocking
+
+使用 `page.route` 攔截網路請求並偽造回應，適合測試錯誤處理與邊界情況。
+
+### 基本用法
+
+```typescript
+// 攔截並偽造回應
+await page.route('**/api/user', async route => {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      id: 1,
+      name: 'Test User',
+      email: 'test@example.com',
+    }),
+  });
+});
+```
+
+### 模擬 API 錯誤
+
+```typescript
+test('處理 API 錯誤', async ({ page }) => {
+  // 模擬 500 錯誤
+  await page.route('**/api/user', async route => {
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'Internal Server Error' }),
+    });
+  });
+
+  await page.goto('/profile');
+  
+  // 驗證錯誤訊息顯示
+  await expect(page.getByText('Failed to load user data')).toBeVisible();
+});
+```
+
+### 模擬網路延遲
+
+```typescript
+await page.route('**/api/products', async route => {
+  // 延遲 3 秒後回應
+  await new Promise(resolve => setTimeout(resolve, 3000));
+  
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ products: [] }),
+  });
+});
+```
+
+### 條件式攔截
+
+```typescript
+await page.route('**/api/**', async route => {
+  const url = route.request().url();
+  
+  if (url.includes('/api/products')) {
+    // 攔截產品 API
+    await route.fulfill({ status: 200, body: '[]' });
+  } else {
+    // 其他請求正常執行
+    await route.continue();
+  }
+});
+```
+
+### 適用情境
+
+- ✅ 測試錯誤處理邏輯
+- ✅ 固定測試資料（避免外部依賴）
+- ✅ 模擬網路中斷或延遲
+- ✅ 測試載入狀態
+- ✅ 隔離前端測試（不依賴後端）
+
+## 自動處理隨機彈窗
+
+使用 `addLocatorHandler` 處理隨機出現的元素，如 Cookie 同意、廣告等。
+
+### 基本用法
+
+```typescript
+test('處理 Cookie 同意彈窗', async ({ page }) => {
+  // 註冊處理器
+  await page.addLocatorHandler(
+    page.getByRole('button', { name: '接受 Cookie' }),
+    async () => {
+      await page.getByRole('button', { name: '接受 Cookie' }).click();
+    }
+  );
+
+  // 正常執行測試
+  await page.goto('/');
+  await page.getByRole('link', { name: 'Products' }).click();
+  // 如果彈窗出現，會自動處理
+});
+```
+
+### 處理多種彈窗
+
+```typescript
+test('處理多種彈窗', async ({ page }) => {
+  // Cookie 同意
+  await page.addLocatorHandler(
+    page.getByRole('button', { name: '接受' }),
+    async () => {
+      await page.getByRole('button', { name: '接受' }).click();
+    }
+  );
+
+  // 訂閱通知
+  await page.addLocatorHandler(
+    page.getByText('訂閱我們的電子報'),
+    async () => {
+      await page.getByRole('button', { name: '關閉' }).click();
+    }
+  );
+
+  // 執行測試
+  await page.goto('/');
+  // 彈窗會自動處理
+});
+```
+
+### 移除處理器
+
+```typescript
+// 註冊處理器
+await page.addLocatorHandler(locator, handler);
+
+// 移除所有處理器
+await page.removeLocatorHandler(locator);
+```
+
+### 注意事項
+
+- ⚠️ 處理器會在每次操作前檢查
+- ⚠️ 可能影響測試效能
+- ⚠️ 僅用於真正隨機出現的元素
+
+## 斷言技巧
+
+### 軟斷言 (Soft Assertions)
+
+失敗時不中止測試，繼續執行後續步驟。
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('多個檢查點', async ({ page }) => {
+  await page.goto('/product/1');
+
+  // 使用軟斷言
+  await expect.soft(page.getByText('Product Name')).toBeVisible();
+  await expect.soft(page.getByText('$99.99')).toBeVisible();
+  await expect.soft(page.getByRole('button', { name: 'Add to cart' })).toBeEnabled();
+
+  // 即使前面的斷言失敗，這裡仍會執行
+  await expect.soft(page.getByText('In Stock')).toBeVisible();
+});
+```
+
+**使用時機**:
+- 單一測試有多個獨立檢查點
+- 想要收集所有失敗資訊
+- 驗證頁面的多個元素
+
+### API 狀態驗證
+
+```typescript
+test('API 回應正常', async ({ request }) => {
+  const response = await request.get('/api/products');
+  
+  // 驗證狀態碼在 200-299 之間
+  expect(response).toBeOK();
+  
+  // 等同於
+  expect(response.status()).toBeGreaterThanOrEqual(200);
+  expect(response.status()).toBeLessThan(300);
+});
+```
+
+### 自訂斷言訊息
+
+```typescript
+await expect(page.getByText('Welcome')).toBeVisible({
+  timeout: 5000,
+  // 自訂錯誤訊息
+  message: '歡迎訊息應該在 5 秒內顯示',
+});
+```
+
+### 陣列與物件斷言
+
+```typescript
+// 陣列包含
+expect(['apple', 'banana', 'orange']).toContain('banana');
+
+// 物件包含屬性
+expect({ name: 'John', age: 30 }).toHaveProperty('name', 'John');
+
+// 部分匹配
+expect({ name: 'John', age: 30, city: 'NYC' }).toMatchObject({
+  name: 'John',
+  age: 30,
+});
+```
+
+## 等待策略
+
+### 等待元素狀態
+
+```typescript
+// 等待可見
+await page.getByRole('button', { name: 'Submit' }).waitFor({ state: 'visible' });
+
+// 等待隱藏
+await page.getByRole('dialog').waitFor({ state: 'hidden' });
+
+// 等待啟用
+await page.getByRole('button', { name: 'Submit' }).waitFor({ state: 'enabled' });
+
+// 等待從 DOM 移除
+await page.getByRole('dialog').waitFor({ state: 'detached' });
+```
+
+### 等待網路請求
+
+```typescript
+// 等待特定 API 完成
+const responsePromise = page.waitForResponse('**/api/products');
+await page.getByRole('button', { name: 'Load Products' }).click();
+const response = await responsePromise;
+expect(response.status()).toBe(200);
+```
+
+### 等待導航
+
+```typescript
+// 等待頁面載入
+await page.waitForLoadState('load');
+
+// 等待網路閒置
+await page.waitForLoadState('networkidle');
+
+// 等待 DOM 內容載入
+await page.waitForLoadState('domcontentloaded');
+```
+
+## 截圖與錄影
+
+### 元素截圖
+
+```typescript
+// 截取特定元素
+await page.getByRole('article').screenshot({ path: 'article.png' });
+
+// 全頁截圖
+await page.screenshot({ path: 'full-page.png', fullPage: true });
+```
+
+### 視覺回歸測試
+
+```typescript
+test('視覺回歸測試', async ({ page }) => {
+  await page.goto('/');
+  
+  // 比對截圖
+  await expect(page).toHaveScreenshot('homepage.png', {
+    maxDiffPixels: 100,  // 允許的差異像素數
+  });
+});
+```
+
+### 錄影
+
+```typescript
+// 在配置中啟用
+export default defineConfig({
+  use: {
+    video: 'on',  // 或 'retain-on-failure'
+  },
+});
+```
+
+## 平行執行控制
+
+### 序列執行
+
+```typescript
+test.describe.serial('依序執行的測試', () => {
+  test('步驟 1', async ({ page }) => {
+    // ...
+  });
+
+  test('步驟 2', async ({ page }) => {
+    // 依賴步驟 1 的結果
+  });
+});
+```
+
+### 限制並行數
+
+```typescript
+// 在配置中設定
+export default defineConfig({
+  workers: 3,  // 最多 3 個並行執行
+});
+
+// 或在測試中設定
+test.describe.configure({ mode: 'parallel' });
+test.describe.configure({ mode: 'serial' });
+```
+
+## 除錯技巧
+
+### Playwright Inspector
+
+```bash
+# 啟動 Inspector
+pnpm playwright test --debug
+
+# 從特定測試開始
+pnpm playwright test Shopping.spec.ts --debug
+```
+
+### 暫停執行
+
+```typescript
+test('除錯測試', async ({ page }) => {
+  await page.goto('/');
+  
+  // 暫停執行，開啟 Inspector
+  await page.pause();
+  
+  await page.getByRole('button', { name: 'Submit' }).click();
+});
+```
+
+### 追蹤檢視器
+
+```bash
+# 生成追蹤檔案
+pnpm playwright test --trace on
+
+# 檢視追蹤
+pnpm playwright show-trace trace.zip
+```
+
+## 相關文件
+
+- [測試架構](./08-test-architecture.md)
+- [元素定位策略](./09-locator-strategies.md)
+- [測試策略](./10-testing-strategies.md)
+- [Playwright API 文件](https://playwright.dev/docs/api/class-playwright)

--- a/docs/agents/14-troubleshooting.md
+++ b/docs/agents/14-troubleshooting.md
@@ -1,0 +1,442 @@
+# 疑難排解
+
+> 本文件說明常見問題與解決方案
+
+## 容器相關問題
+
+### 容器啟動失敗
+
+**症狀**: 執行 `pnpm run compose-up` 後容器無法啟動
+
+**檢查項目**:
+
+1. **確認 Podman/Docker 正在運行**
+   ```bash
+   # 檢查 Podman 狀態
+   podman info
+   
+   # 或檢查 Docker 狀態
+   docker info
+   ```
+
+2. **檢查 .env 檔案**
+   ```bash
+   # 確認檔案存在
+   ls -la .env
+   
+   # 檢查內容
+   cat .env
+   ```
+   
+   必要的環境變數：
+   - `ORACLE_TEST_USERNAME`
+   - `ORACLE_TEST_PASSWORD`
+
+3. **查看容器日誌**
+   ```bash
+   # Spring Boot 應用日誌
+   podman logs spring-boot-app-test
+   
+   # Oracle DB 日誌
+   podman logs oracle-db-test
+   ```
+
+4. **檢查 Port 佔用**
+   ```bash
+   # Windows (PowerShell)
+   netstat -ano | findstr :8787
+   netstat -ano | findstr :1521
+   
+   # Linux/macOS
+   lsof -i :8787
+   lsof -i :1521
+   ```
+
+**解決方式**:
+
+```bash
+# 完全清理並重新啟動
+podman compose -f docker-compose.test.yml down -v
+podman compose -f docker-compose.test.yml up -d
+
+# 等待服務啟動
+sleep 30
+```
+
+### 容器健康檢查失敗
+
+**症狀**: 容器啟動但健康檢查一直失敗
+
+**檢查方式**:
+
+```bash
+# 檢查容器狀態
+podman ps -a
+
+# 手動執行健康檢查
+podman exec oracle-db-test healthcheck.sh
+```
+
+**常見原因**:
+
+1. **Oracle DB 初始化未完成**
+   - Oracle DB 需要 1-2 分鐘完全啟動
+   - 解決：增加等待時間
+
+2. **PDB 未開啟**
+   ```bash
+   # 進入容器檢查
+   podman exec -it oracle-db-test sqlplus sys/password@//localhost:1521/FREEPDB1 as sysdba
+   
+   # 檢查 PDB 狀態
+   SELECT name, open_mode FROM v$pdbs;
+   
+   # 如果是 MOUNTED，手動開啟
+   ALTER PLUGGABLE DATABASE FREEPDB1 OPEN;
+   ```
+
+3. **記憶體不足**
+   - Oracle DB 需要至少 2GB 記憶體
+   - 解決：增加 Docker/Podman 記憶體限制
+
+## 測試連線問題
+
+### 測試連線失敗
+
+**錯誤訊息**: `connect ECONNREFUSED ::1:8787`
+
+**原因分析**:
+- Spring Boot 應用尚未完全啟動
+- Port 8787 被其他程式佔用
+- 防火牆阻擋連線
+
+**解決步驟**:
+
+1. **確認容器正在運行**
+   ```bash
+   podman ps
+   ```
+   
+   應該看到：
+   - `spring-boot-app-test` (healthy)
+   - `oracle-db-test` (healthy)
+
+2. **等待 Spring Boot 完全啟動**
+   ```bash
+   # 持續檢查健康狀態
+   curl http://localhost:8787/actuator/health
+   
+   # 或查看日誌
+   podman logs -f spring-boot-app-test
+   ```
+   
+   等待看到：
+   ```
+   Started Application in X.XXX seconds
+   ```
+
+3. **檢查 Port 是否被佔用**
+   ```bash
+   # Windows
+   netstat -ano | findstr :8787
+   
+   # Linux/macOS
+   lsof -i :8787
+   ```
+
+4. **測試連線**
+   ```bash
+   # 使用 curl 測試
+   curl -v http://localhost:8787/actuator/health
+   
+   # 或使用 PowerShell
+   Invoke-WebRequest -Uri http://localhost:8787/actuator/health
+   ```
+
+**建議等待時間**:
+- 本地開發：10-20 秒
+- CI 環境：30-60 秒
+
+### API 請求超時
+
+**症狀**: 測試執行時 API 請求超時
+
+**解決方式**:
+
+1. **增加超時時間**
+   ```typescript
+   // playwright.config.ts
+   export default defineConfig({
+     timeout: 60 * 1000,  // 從 30 秒增加到 60 秒
+   });
+   ```
+
+2. **檢查網路連線**
+   ```bash
+   # 測試 API 回應時間
+   curl -w "@curl-format.txt" -o /dev/null -s http://localhost:8787/api/products
+   ```
+
+3. **查看應用日誌**
+   ```bash
+   podman logs spring-boot-app-test | grep ERROR
+   ```
+
+## Oracle DB 問題
+
+### Oracle DB 啟動超時
+
+**症狀**: Oracle DB 容器啟動超過 5 分鐘仍未就緒
+
+**解決方式**:
+
+1. **增加等待時間**
+   ```typescript
+   // 在測試腳本中
+   const maxWait = 300000;  // 從 120 秒增加到 300 秒
+   ```
+
+2. **確認系統資源充足**
+   ```bash
+   # 檢查記憶體使用
+   free -h  # Linux
+   Get-ComputerInfo | Select-Object CsPhysicallyInstalledMemory  # Windows
+   ```
+   
+   Oracle DB 建議配置：
+   - 記憶體：至少 2GB
+   - CPU：至少 2 核心
+   - 磁碟空間：至少 10GB
+
+3. **檢查 Oracle DB 日誌**
+   ```bash
+   podman logs oracle-db-test | tail -100
+   ```
+
+4. **手動重啟**
+   ```bash
+   podman restart oracle-db-test
+   ```
+
+### 資料庫連線錯誤
+
+**錯誤訊息**: `ORA-12541: TNS:no listener`
+
+**解決方式**:
+
+1. **檢查 Listener 狀態**
+   ```bash
+   podman exec oracle-db-test lsnrctl status
+   ```
+
+2. **重啟 Listener**
+   ```bash
+   podman exec oracle-db-test lsnrctl stop
+   podman exec oracle-db-test lsnrctl start
+   ```
+
+3. **檢查連線字串**
+   ```bash
+   # 正確格式
+   jdbc:oracle:thin:@localhost:1521/FREEPDB1
+   
+   # 錯誤格式（缺少 PDB 名稱）
+   jdbc:oracle:thin:@localhost:1521
+   ```
+
+## Playwright 測試問題
+
+### 元素找不到
+
+**錯誤訊息**: `Error: locator.click: Timeout 30000ms exceeded`
+
+**解決步驟**:
+
+1. **檢查元素是否存在**
+   ```typescript
+   // 使用 Playwright Inspector
+   await page.pause();
+   ```
+
+2. **增加等待時間**
+   ```typescript
+   await page.getByRole('button', { name: 'Submit' }).click({ timeout: 60000 });
+   ```
+
+3. **檢查元素是否被遮擋**
+   ```typescript
+   // 滾動到元素位置
+   await page.getByRole('button', { name: 'Submit' }).scrollIntoViewIfNeeded();
+   await page.getByRole('button', { name: 'Submit' }).click();
+   ```
+
+4. **使用更穩健的定位器**
+   ```typescript
+   // ❌ 脆弱
+   await page.locator('.btn-primary').click();
+   
+   // ✅ 穩健
+   await page.getByRole('button', { name: 'Submit' }).click();
+   ```
+
+### 測試不穩定（Flaky）
+
+**症狀**: 測試有時通過，有時失敗
+
+**常見原因與解決方式**:
+
+1. **競態條件**
+   ```typescript
+   // ❌ 不穩定
+   await page.click('button');
+   await expect(page.locator('.result')).toBeVisible();
+   
+   // ✅ 穩定
+   await page.click('button');
+   await page.waitForResponse('**/api/submit');
+   await expect(page.locator('.result')).toBeVisible();
+   ```
+
+2. **動畫干擾**
+   ```typescript
+   // 停用動畫
+   export default defineConfig({
+     use: {
+       actionTimeout: 10000,
+       navigationTimeout: 30000,
+     },
+   });
+   ```
+
+3. **網路延遲**
+   ```typescript
+   // 等待網路閒置
+   await page.waitForLoadState('networkidle');
+   ```
+
+### 截圖或錄影失敗
+
+**症狀**: 測試失敗但沒有生成截圖或錄影
+
+**檢查配置**:
+
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  use: {
+    screenshot: 'only-on-failure',  // 確保已啟用
+    video: 'retain-on-failure',
+    trace: 'retain-on-failure',
+  },
+});
+```
+
+**檢查權限**:
+
+```bash
+# 確認輸出目錄可寫入
+ls -la playwright-report/
+ls -la test-results/
+```
+
+## 效能問題
+
+### 測試執行緩慢
+
+**優化建議**:
+
+1. **增加並行執行數**
+   ```typescript
+   export default defineConfig({
+     workers: 4,  // 根據 CPU 核心數調整
+   });
+   ```
+
+2. **使用 storageState 避免重複登入**
+   - 參考：[測試策略 - 全域登入狀態分享](./10-testing-strategies.md#全域登入狀態分享)
+
+3. **減少不必要的等待**
+   ```typescript
+   // ❌ 固定等待
+   await page.waitForTimeout(5000);
+   
+   // ✅ 條件等待
+   await page.waitForLoadState('networkidle');
+   ```
+
+4. **停用不需要的功能**
+   ```typescript
+   export default defineConfig({
+     use: {
+       video: 'off',  // 本地開發時停用
+       trace: 'off',
+     },
+   });
+   ```
+
+## 環境問題
+
+### Node.js 版本不相容
+
+**錯誤訊息**: `Error: The engine "node" is incompatible`
+
+**解決方式**:
+
+```bash
+# 檢查 Node.js 版本
+node --version
+
+# 升級到 v18 或更高版本
+# 使用 nvm (推薦)
+nvm install 20
+nvm use 20
+
+# 或使用 fnm
+fnm install 20
+fnm use 20
+```
+
+### pnpm 指令找不到
+
+**錯誤訊息**: `pnpm: command not found`
+
+**解決方式**:
+
+```bash
+# 安裝 pnpm
+npm install -g pnpm
+
+# 或使用 corepack (Node.js 16.13+)
+corepack enable
+corepack prepare pnpm@latest --activate
+```
+
+## 取得協助
+
+如果問題仍未解決：
+
+1. **查看詳細日誌**
+   ```bash
+   # Playwright 詳細輸出
+   DEBUG=pw:api pnpm playwright test
+   
+   # 容器日誌
+   podman logs --tail 100 spring-boot-app-test
+   podman logs --tail 100 oracle-db-test
+   ```
+
+2. **檢查相關文件**
+   - [環境準備](./02-environment-setup.md)
+   - [CI/CD 整合](./11-cicd-integration.md)
+   - [測試策略](./10-testing-strategies.md)
+
+3. **參考官方文件**
+   - [Playwright 疑難排解](https://playwright.dev/docs/troubleshooting)
+   - [Docker Compose 疑難排解](https://docs.docker.com/compose/troubleshooting/)
+
+## 相關文件
+
+- [環境準備](./02-environment-setup.md)
+- [快速開始](./03-quick-start.md)
+- [CI/CD 整合](./11-cicd-integration.md)
+- [配置指南](./12-configuration-guide.md)


### PR DESCRIPTION
## 變更內容

### 1. AGENTS.md 模組化重構
- 拆分 440 行單一文件為 14 個主題模組
- 主文件使用 `@` 語法引用模組
- 5 大分類：專案基礎、開發規範、架構設計、測試與部署、維運支援

### 2. Oracle 健康檢查改進
- 改用 SYS 使用者執行健康檢查
- 檢查 PDB 狀態（READ WRITE）確保完全就緒

## Commits
- `80294c4` - docs: refactor AGENTS.md into modular structure
- `148031a` - test: enhance Oracle database healthcheck reliability