### PR TITLE
docs: reorganize E2E cleanup strategy documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ This file provides guidance to agents when working with code in this repository.
 ## 相關文件
 
 - [筆記.md](./筆記.md) - 詳細的開發指南和最佳實踐
-- [E2E-TESTING-CLEANUP-STRATEGY.md](./E2E-TESTING-CLEANUP-STRATEGY.md) - 測試資料清理策略
+- [docs/testing/e2e-cleanup-strategy.md](./docs/testing/e2e-cleanup-strategy.md) - 測試資料清理策略
 - [.github/instructions/Global.instructions.md](./.github/instructions/Global.instructions.md) - 開發規範
 - [Playwright 官方文件](https://playwright.dev/docs/intro)
 - [Docker Compose 文件](https://docs.docker.com/compose/)

--- a/docs/agents/10-testing-strategies.md
+++ b/docs/agents/10-testing-strategies.md
@@ -67,8 +67,8 @@ pnpm playwright test --project=api-e2e
 - ❌ 單元測試（過於重量級）
 
 ### 詳細說明
+完整的策略分析請參考：[e2e-cleanup-strategy.md](../testing/e2e-cleanup-strategy.md)
 
-完整的策略分析請參考：[E2E-TESTING-CLEANUP-STRATEGY.md](../../E2E-TESTING-CLEANUP-STRATEGY.md)
 
 ## 全域登入狀態分享
 
@@ -263,4 +263,4 @@ test('完整購物流程', { tag: '@regression' }, async ({ page }) => {
 - [快速開始](./03-quick-start.md)
 - [CI/CD 整合](./11-cicd-integration.md)
 - [配置指南](./12-configuration-guide.md)
-- [E2E 測試清理策略](../../E2E-TESTING-CLEANUP-STRATEGY.md)
+- [E2E 測試清理策略](../testing/e2e-cleanup-strategy.md)

--- a/docs/testing/e2e-cleanup-strategy.md
+++ b/docs/testing/e2e-cleanup-strategy.md
@@ -12,7 +12,7 @@
 
 **工作原理**：
 - 每次測試執行前停止並刪除所有測試容器和 volumes
-- 重新啟動 Docker Compose 環境（Spring Boot + Oracle DB）
+- 重新啟動 podman compose 環境（Spring Boot + Oracle DB）
 - Spring Boot 啟動時會自動執行 Flyway migrate
 - 等待服務健康檢查通過後執行測試
 
@@ -38,13 +38,13 @@
 
 ```bash
 # 1. 啟動測試環境（只需執行一次）
-npm run compose-up
+pnpm run compose-up
 
 # 2. 執行測試（可重複執行）
-npm run test:e2e
+pnpm run test:e2e
 
 # 3. 停止測試環境（可選）
-npm run compose-down
+pnpm run compose-down
 ```
 
 **注意**：
@@ -64,8 +64,8 @@ npm run compose-down
 # Linux/macOS (Bash)
 bash scripts/test-e2e-ci.sh
 
-# 或使用 npm script
-npm run test:e2e:ci
+# 或使用 pnpm script
+pnpm run test:e2e:ci
 ```
 
 **腳本會自動執行**：
@@ -124,14 +124,14 @@ export default defineConfig({
 
 ```bash
 # 1. 啟動測試環境
-npm run compose-up
+pnpm run compose-up
 
 # 2. 等待容器啟動完成（約 1-2 分鐘）
 # 可以使用以下指令檢查狀態：
 podman ps
 
 # 3. 執行測試
-npm run test:e2e
+pnpm run test:e2e
 ```
 
 ### CI/CD Pipeline
@@ -139,7 +139,7 @@ npm run test:e2e
 ```yaml
 # GitHub Actions 範例
 - name: Run E2E Tests
-  run: npm run test:e2e:ci
+  run: pnpm run test:e2e:ci
   env:
     ORACLE_TEST_USERNAME: ${{ secrets.ORACLE_TEST_USERNAME }}
     ORACLE_TEST_PASSWORD: ${{ secrets.ORACLE_TEST_PASSWORD }}
@@ -169,7 +169,7 @@ ORACLE_TEST_PASSWORD=your_password
 
 **方式 1（手動啟動）**：
 - 容器保持運行，測試資料會累積
-- 如需乾淨環境，執行 `npm run compose-restart`
+- 如需乾淨環境，執行 `pnpm run compose-restart`
 
 **方式 2（容器重啟）**：
 - 每次都是全新環境，無資料累積問題
@@ -181,7 +181,7 @@ ORACLE_TEST_PASSWORD=your_password
 ### 問題 1：容器啟動失敗
 
 **檢查項目**：
-1. 確認 Docker/Podman 正在運行
+1. 確認 podman 正在運行
 2. 檢查 `.env` 檔案是否存在且正確
 3. 查看容器日誌：`podman logs spring-boot-app-test`
 
@@ -252,7 +252,7 @@ ORACLE_TEST_PASSWORD=your_password
 ## 📚 相關文件
 
 - [Playwright 官方文件](https://playwright.dev/docs/intro)
-- [Docker Compose 文件](https://docs.docker.com/compose/)
+- [Podman Compose 文件](https://docs.podman.io/en/latest/markdown/podman-compose.1.html)
 - [Flyway 官方文件](https://flywaydb.org/documentation/)
 
 ---


### PR DESCRIPTION
## Summary
- move [`E2E-TESTING-CLEANUP-STRATEGY.md`](E2E-TESTING-CLEANUP-STRATEGY.md) to [`docs/testing/e2e-cleanup-strategy.md`](docs/testing/e2e-cleanup-strategy.md)
- update related references in [`AGENTS.md`](AGENTS.md) and [`docs/agents/10-testing-strategies.md`](docs/agents/10-testing-strategies.md)
- align documentation terminology with project conventions (`pnpm`, `podman`)

## Why
- keep project-level documentation organized under [`docs/`](docs/)
- make testing strategy documents easier to find and maintain
- keep wording consistent with repository standards

## Scope
- documentation only
- no application logic changes
- no test behavior changes