### PR TITLE
docs(agents): add workflow guidelines and skills lock file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,12 @@ This file provides guidance to agents when working with code in this repository.
 5. **優先使用 `getByRole`**: 最穩健的元素定位方式
 6. **容器重啟策略**: 確保測試隔離性和可重複性
 7. **繁體中文優先**: 所有註解和文件使用繁體中文
+8. **持續改進文件**: 發現可改進的 instruction 時，應主動提出並更新相關文件
+9. **遵循 Git 工作流程**:
+   - 必須在適當的 feature 分支上進行開發（參考 [@Git 工作流程](docs/agents/05-git-workflow.md)）
+   - 推送後需清理本地和遠端分支（合併後刪除 feature 分支）
+   - 使用 `git checkout main && git pull && git branch -d <branch-name>` 清理本地分支
+   - 使用 `git push origin --delete <branch-name>` 清理遠端分支（如需要）
 
 ---
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "skills": {
+    "caveman": {
+      "source": "juliusbrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman/SKILL.md",
+      "computedHash": "7935e83f9c6a8b7cbb5404d144b0d19e3ba93583f4388301c3dada37cd25adf8"
+    },
+    "find-skills": {
+      "source": "vercel-labs/skills",
+      "sourceType": "github",
+      "skillPath": "skills/find-skills/SKILL.md",
+      "computedHash": "9e1c8b3103f92fa8092568a44fe64858de7c5c9dc65ce4bea8f168080e889cfd"
+    },
+    "github-actions-docs": {
+      "source": "xixu-me/skills",
+      "sourceType": "github",
+      "skillPath": "skills/github-actions-docs/SKILL.md",
+      "computedHash": "ead3fa2aff18e829c468dee593e1dc897aa95dc7a07d9ff8ff9f30c296b19af8"
+    },
+    "skill-creator": {
+      "source": "anthropics/skills",
+      "sourceType": "github",
+      "skillPath": "skills/skill-creator/SKILL.md",
+      "computedHash": "7e3c9cd74e9e2b4828527a857170e86310f2dab5ea8030a9043df2c7e6c88857"
+    },
+    "skills-cli": {
+      "source": "xixu-me/skills",
+      "sourceType": "github",
+      "skillPath": "skills/skills-cli/SKILL.md",
+      "computedHash": "712dc9e845f46d88ec598f0fb372f10b3fbf18ed2546d1cc321eeb44f8db239a"
+    }
+  }
+}


### PR DESCRIPTION
## 變更摘要

本 PR 更新 AGENTS.md 文件並新增 skills-lock.json 配置檔案。

## 變更內容

### AGENTS.md
- 新增「持續改進文件」指引（#8）
- 新增「遵循 Git 工作流程」規範（#9）
  - 分支開發規範
  - 分支清理指令
  - 本地和遠端分支管理

### skills-lock.json
- 新增技能鎖定檔案
- 包含 5 個已安裝技能：caveman, find-skills, github-actions-docs, skill-creator, skills-cli