### PR TITLE
fix(api): update order API to use 'items' field

### DIFF
--- a/services/apis/springboot-api-client.ts
+++ b/services/apis/springboot-api-client.ts
@@ -1,5 +1,5 @@
 import type { APIRequestContext } from '@playwright/test';
-import type { components } from '../schema/api-types';
+import type { components, PageResponse } from '../schema/api-types';
 import { type ApiError, ApiRequester, type ApiResult } from './base-api-client';
 
 type Schemas = components['schemas'];
@@ -90,9 +90,17 @@ export class SpringbootApiClient {
 		return this.requester.get<Schemas['GetOrderDetailResponse']>(`${this.endpoints.order}/${id}`);
 	}
 
-	listOrdersByAccount(accountId: number): Promise<ApiResult<Schemas['GetOrderListResponse'][]>> {
-		return this.requester.get<Schemas['GetOrderListResponse'][]>(
+	listOrdersByAccount(
+		accountId: number,
+		params?: {
+			page?: number;
+			size?: number;
+			sort?: string;
+		},
+	): Promise<ApiResult<PageResponse<Schemas['GetOrderListResponse']>>> {
+		return this.requester.get<PageResponse<Schemas['GetOrderListResponse']>>(
 			`${this.endpoints.order}/account/${accountId}`,
+			params ? { params } : undefined,
 		);
 	}
 

--- a/services/fixtures/springboot-api-objects.fixture.ts
+++ b/services/fixtures/springboot-api-objects.fixture.ts
@@ -41,9 +41,7 @@ export const springbootApiTest = baseTest.extend<SpringbootApiFixtures>({
 		// 在 fixture 中建立一筆訂單資料
 		const response = await springbootApi.createOrder({
 			accountId: existingAccount.id,
-			orderDetails: [
-				{ productId: existingProductId, quantity: faker.number.int({ min: 1, max: 5 }) },
-			],
+			items: [{ productId: existingProductId, quantity: faker.number.int({ min: 1, max: 5 }) }],
 		});
 		const orderId = expectOk(response);
 
@@ -56,13 +54,13 @@ export const springbootApiTest = baseTest.extend<SpringbootApiFixtures>({
 		// 建立多張訂單，確保有多筆資料
 		const orderResponse1 = await springbootApi.createOrder({
 			accountId: existingAccount.id,
-			orderDetails: [{ productId: existingProductId, quantity: 1 }],
+			items: [{ productId: existingProductId, quantity: 1 }],
 		});
 		expectOk(orderResponse1);
 
 		const orderResponse2 = await springbootApi.createOrder({
 			accountId: existingAccount.id,
-			orderDetails: [{ productId: existingProductId, quantity: 1 }],
+			items: [{ productId: existingProductId, quantity: 1 }],
 		});
 		expectOk(orderResponse2);
 

--- a/services/fixtures/springboot-test-data.fixture.ts
+++ b/services/fixtures/springboot-test-data.fixture.ts
@@ -58,7 +58,7 @@ export const springbootTestData = baseTest.extend<SpringbootDataFixtures>({
 	newOrderData: async ({}, use) => {
 		await use((accountId, productId) => ({
 			accountId: accountId,
-			orderDetails: [{ productId: productId, quantity: 1 }],
+			items: [{ productId: productId, quantity: 1 }],
 		}));
 	},
 

--- a/services/schema/api-types.ts
+++ b/services/schema/api-types.ts
@@ -340,34 +340,21 @@ export interface components {
 /**
  * 分頁回應的通用型別
  * 用於包裝分頁資料的標準格式
+ *
+ * 注意：此介面根據實際後端 API 回應定義
+ * 後端使用簡化版的分頁回應，而非完整的 Spring Data Page 物件
  */
 export interface PageResponse<T> {
+	/** 分頁內容陣列 */
 	content: T[];
-	pageable: {
-		pageNumber: number;
-		pageSize: number;
-		sort: {
-			sorted: boolean;
-			unsorted: boolean;
-			empty: boolean;
-		};
-		offset: number;
-		paged: boolean;
-		unpaged: boolean;
-	};
-	totalPages: number;
-	totalElements: number;
-	last: boolean;
+	/** 當前頁碼（從 0 開始） */
+	page: number;
+	/** 每頁大小 */
 	size: number;
-	number: number;
-	sort: {
-		sorted: boolean;
-		unsorted: boolean;
-		empty: boolean;
-	};
-	numberOfElements: number;
-	first: boolean;
-	empty: boolean;
+	/** 總元素數量 */
+	totalElements: number;
+	/** 總頁數 */
+	totalPages: number;
 }
 export type $defs = Record<string, never>;
 export interface operations {

--- a/services/schema/api-types.ts
+++ b/services/schema/api-types.ts
@@ -4,757 +4,757 @@
  */
 
 export interface paths {
-    "/product/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getProductDetail"];
-        /**
-         * 更新商品
-         * @description 該ID商品若沒找到拋出NotFound例外，再檢查是否要更改成已經存在的商品名稱拋出特定例外，沒有則更新成功
-         */
-        put: operations["updateProduct"];
-        post?: never;
-        /**
-         * 刪除商品
-         * @description 找不到商品或商品已經軟刪除過拋出NotFound，沒有則軟刪除
-         */
-        delete: operations["deleteProduct"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/order": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * 更新訂單內容
-         * @description 不存在該訂單ID拋出NotFound，若商品狀態不可銷售拋出特定例外，再來若有商品庫存不足拋出特定例外，都沒更新商品庫存、訂單
-         */
-        put: operations["updateOrder"];
-        /**
-         * 建立新訂單
-         * @description 帳戶狀態N拋出特定例外，之後若商品狀態不可銷售拋出特定例外，再來若商品庫存不足拋出特定例外，沒例外則更新商品庫存和新增訂單
-         */
-        post: operations["createOrder"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/account/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getAccountDetail"];
-        /**
-         * 修改帳戶
-         * @description 該ID帳戶不存在拋出NotFound例外，再檢查是否狀態從Y改成N，帳戶有關連到的訂單的話拋出例外，都沒事就更新成功
-         */
-        put: operations["updateAccount"];
-        post?: never;
-        /**
-         * 刪除帳戶
-         * @description 找不到帳戶或帳戶已經軟刪除過拋出NotFound，如果仍關聯訂單拋出特定例外，沒有則軟刪除
-         */
-        delete: operations["deleteAccount"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/product": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getProductList"];
-        put?: never;
-        /**
-         * 新增商品
-         * @description 如果有同名商品拋出特定例外，沒有則新增成功
-         */
-        post: operations["createProduct"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/product/processOrderItems": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * 處理訂單中的商品
-         * @description 處理訂單中的商品資訊
-         */
-        post: operations["processOrderItems"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/account": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getAccountList"];
-        put?: never;
-        post: operations["createAccount"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/PlaywrightTestData/createOrderPrecondition": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["createOrderPrecondition"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/product/batch": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getProductBatch"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/order/{orderId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getOrderDetails"];
-        put?: never;
-        post?: never;
-        /**
-         * 刪除訂單
-         * @description 訂單id不存在或狀態已經為1003取消拋出NotFound，都沒有則軟刪除更新OrderInfo的狀態資料欄位，真刪除OrderDetail並歸還商品庫存
-         */
-        delete: operations["deleteOrder"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/order/account/{accountId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getOrderList"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/order/account/{accountId}/exists": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 檢查帳戶ID是否存在於任何訂單中
-         * @description 判斷帳戶有沒有在訂單中，讓帳戶在更新狀態和刪除時檢核用，只在傳入的帳戶ID有關連訂單時回傳TRUE，傳入不存在和沒再訂單中的帳戶ID也回傳false
-         */
-        get: operations["AccountIdIsInOrder"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+	'/product/{id}': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get: operations['getProductDetail'];
+		/**
+		 * 更新商品
+		 * @description 該ID商品若沒找到拋出NotFound例外，再檢查是否要更改成已經存在的商品名稱拋出特定例外，沒有則更新成功
+		 */
+		put: operations['updateProduct'];
+		post?: never;
+		/**
+		 * 刪除商品
+		 * @description 找不到商品或商品已經軟刪除過拋出NotFound，沒有則軟刪除
+		 */
+		delete: operations['deleteProduct'];
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/order': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		/**
+		 * 更新訂單內容
+		 * @description 不存在該訂單ID拋出NotFound，若商品狀態不可銷售拋出特定例外，再來若有商品庫存不足拋出特定例外，都沒更新商品庫存、訂單
+		 */
+		put: operations['updateOrder'];
+		/**
+		 * 建立新訂單
+		 * @description 帳戶狀態N拋出特定例外，之後若商品狀態不可銷售拋出特定例外，再來若商品庫存不足拋出特定例外，沒例外則更新商品庫存和新增訂單
+		 */
+		post: operations['createOrder'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/account/{id}': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get: operations['getAccountDetail'];
+		/**
+		 * 修改帳戶
+		 * @description 該ID帳戶不存在拋出NotFound例外，再檢查是否狀態從Y改成N，帳戶有關連到的訂單的話拋出例外，都沒事就更新成功
+		 */
+		put: operations['updateAccount'];
+		post?: never;
+		/**
+		 * 刪除帳戶
+		 * @description 找不到帳戶或帳戶已經軟刪除過拋出NotFound，如果仍關聯訂單拋出特定例外，沒有則軟刪除
+		 */
+		delete: operations['deleteAccount'];
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/product': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get: operations['getProductList'];
+		put?: never;
+		/**
+		 * 新增商品
+		 * @description 如果有同名商品拋出特定例外，沒有則新增成功
+		 */
+		post: operations['createProduct'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/product/processOrderItems': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * 處理訂單中的商品
+		 * @description 處理訂單中的商品資訊
+		 */
+		post: operations['processOrderItems'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/account': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get: operations['getAccountList'];
+		put?: never;
+		post: operations['createAccount'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/PlaywrightTestData/createOrderPrecondition': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		post: operations['createOrderPrecondition'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/product/batch': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get: operations['getProductBatch'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/order/{orderId}': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get: operations['getOrderDetails'];
+		put?: never;
+		post?: never;
+		/**
+		 * 刪除訂單
+		 * @description 訂單id不存在或狀態已經為1003取消拋出NotFound，都沒有則軟刪除更新OrderInfo的狀態資料欄位，真刪除OrderDetail並歸還商品庫存
+		 */
+		delete: operations['deleteOrder'];
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/order/account/{accountId}': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get: operations['getOrderList'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/order/account/{accountId}/exists': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * 檢查帳戶ID是否存在於任何訂單中
+		 * @description 判斷帳戶有沒有在訂單中，讓帳戶在更新狀態和刪除時檢核用，只在傳入的帳戶ID有關連訂單時回傳TRUE，傳入不存在和沒再訂單中的帳戶ID也回傳false
+		 */
+		get: operations['AccountIdIsInOrder'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        UpdateProductRequest: {
-            name?: string;
-            price: number;
-            /** Format: int32 */
-            saleStatus: number;
-            /** Format: int32 */
-            available: number;
-        };
-        UpdateOrderDetailRequest: {
-            /** Format: int32 */
-            productId: number;
-            /** Format: int32 */
-            quantity: number;
-        };
-        UpdateOrderRequest: {
-            /** Format: int32 */
-            orderId: number;
-            /** Format: int32 */
-            orderStatus: number;
-            items?: components["schemas"]["UpdateOrderDetailRequest"][];
-        };
-        UpdateAccountRequest: {
-            name?: string;
-            status?: string;
-        };
-        CreateProductRequest: {
-            name?: string;
-            price: number;
-            /** Format: int32 */
-            available: number;
-        };
-        OrderItemRequest: {
-            /** Format: int32 */
-            productId?: number;
-            /** Format: int32 */
-            quantity?: number;
-        };
-        ProcessOrderItemsRequest: {
-            originalItems?: components["schemas"]["OrderItemRequest"][];
-            updatedItems?: components["schemas"]["OrderItemRequest"][];
-        };
-        CreateOrderDetailRequest: {
-            /** Format: int32 */
-            productId: number;
-            /** Format: int32 */
-            quantity: number;
-        };
-        CreateOrderRequest: {
-            /** Format: int32 */
-            accountId: number;
-            orderDetails?: components["schemas"]["CreateOrderDetailRequest"][];
-        };
-        CreateAccountRequest: {
-            name?: string;
-        };
-        GetProductListResponse: {
-            /** Format: int32 */
-            id?: number;
-            name?: string;
-            price?: number;
-            /** Format: int32 */
-            saleStatus?: number;
-            /** Format: int32 */
-            available?: number;
-        };
-        GetProductDetailResponse: {
-            name?: string;
-            price?: number;
-            /** Format: int32 */
-            saleStatus?: number;
-            /** Format: int32 */
-            available?: number;
-        };
-        GetOrderDetailResponse: {
-            /** Format: int32 */
-            accountId?: number;
-            /** Format: int32 */
-            orderStatus?: number;
-            totalAmount?: number;
-            items?: components["schemas"]["OrderItemDTO"][];
-        };
-        OrderItemDTO: {
-            /** Format: int32 */
-            productId?: number;
-            productName?: string;
-            /** Format: int32 */
-            quantity?: number;
-            productPrice?: number;
-        };
-        GetOrderListResponse: {
-            /** Format: int32 */
-            orderId?: number;
-            /** Format: int32 */
-            status?: number;
-            totalAmount?: number;
-        };
-        GetAccountListResponse: {
-            /** Format: int32 */
-            id?: number;
-            name?: string;
-            status?: string;
-        };
-        GetAccountDetailResponse: {
-            name?: string;
-            status?: string;
-        };
-    };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+	schemas: {
+		UpdateProductRequest: {
+			name?: string;
+			price: number;
+			/** Format: int32 */
+			saleStatus: number;
+			/** Format: int32 */
+			available: number;
+		};
+		UpdateOrderDetailRequest: {
+			/** Format: int32 */
+			productId: number;
+			/** Format: int32 */
+			quantity: number;
+		};
+		UpdateOrderRequest: {
+			/** Format: int32 */
+			orderId: number;
+			/** Format: int32 */
+			orderStatus: number;
+			items?: components['schemas']['UpdateOrderDetailRequest'][];
+		};
+		UpdateAccountRequest: {
+			name?: string;
+			status?: string;
+		};
+		CreateProductRequest: {
+			name?: string;
+			price: number;
+			/** Format: int32 */
+			available: number;
+		};
+		OrderItemRequest: {
+			/** Format: int32 */
+			productId?: number;
+			/** Format: int32 */
+			quantity?: number;
+		};
+		ProcessOrderItemsRequest: {
+			originalItems?: components['schemas']['OrderItemRequest'][];
+			updatedItems?: components['schemas']['OrderItemRequest'][];
+		};
+		CreateOrderDetailRequest: {
+			/** Format: int32 */
+			productId: number;
+			/** Format: int32 */
+			quantity: number;
+		};
+		CreateOrderRequest: {
+			/** Format: int32 */
+			accountId: number;
+			items?: components['schemas']['CreateOrderDetailRequest'][];
+		};
+		CreateAccountRequest: {
+			name?: string;
+		};
+		GetProductListResponse: {
+			/** Format: int32 */
+			id?: number;
+			name?: string;
+			price?: number;
+			/** Format: int32 */
+			saleStatus?: number;
+			/** Format: int32 */
+			available?: number;
+		};
+		GetProductDetailResponse: {
+			name?: string;
+			price?: number;
+			/** Format: int32 */
+			saleStatus?: number;
+			/** Format: int32 */
+			available?: number;
+		};
+		GetOrderDetailResponse: {
+			/** Format: int32 */
+			accountId?: number;
+			/** Format: int32 */
+			orderStatus?: number;
+			totalAmount?: number;
+			items?: components['schemas']['OrderItemDTO'][];
+		};
+		OrderItemDTO: {
+			/** Format: int32 */
+			productId?: number;
+			productName?: string;
+			/** Format: int32 */
+			quantity?: number;
+			productPrice?: number;
+		};
+		GetOrderListResponse: {
+			/** Format: int32 */
+			orderId?: number;
+			/** Format: int32 */
+			status?: number;
+			totalAmount?: number;
+		};
+		GetAccountListResponse: {
+			/** Format: int32 */
+			id?: number;
+			name?: string;
+			status?: string;
+		};
+		GetAccountDetailResponse: {
+			name?: string;
+			status?: string;
+		};
+	};
+	responses: never;
+	parameters: never;
+	requestBodies: never;
+	headers: never;
+	pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    getProductDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["GetProductDetailResponse"];
-                };
-            };
-        };
-    };
-    updateProduct: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateProductRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    deleteProduct: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    updateOrder: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateOrderRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    createOrder: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateOrderRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": number;
-                };
-            };
-        };
-    };
-    getAccountDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["GetAccountDetailResponse"];
-                };
-            };
-        };
-    };
-    updateAccount: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateAccountRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    deleteAccount: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getProductList: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["GetProductListResponse"][];
-                };
-            };
-        };
-    };
-    createProduct: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateProductRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": number;
-                };
-            };
-        };
-    };
-    processOrderItems: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ProcessOrderItemsRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getAccountList: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["GetAccountListResponse"][];
-                };
-            };
-        };
-    };
-    createAccount: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateAccountRequest"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": number;
-                };
-            };
-        };
-    };
-    createOrderPrecondition: {
-        parameters: {
-            query: {
-                count: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": string;
-                };
-            };
-        };
-    };
-    getProductBatch: {
-        parameters: {
-            query: {
-                ids: number[];
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["GetProductDetailResponse"][];
-                };
-            };
-        };
-    };
-    getOrderDetails: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                orderId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["GetOrderDetailResponse"];
-                };
-            };
-        };
-    };
-    deleteOrder: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                orderId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getOrderList: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                accountId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["GetOrderListResponse"][];
-                };
-            };
-        };
-    };
-    AccountIdIsInOrder: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                accountId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": boolean;
-                };
-            };
-        };
-    };
+	getProductDetail: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				id: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': components['schemas']['GetProductDetailResponse'];
+				};
+			};
+		};
+	};
+	updateProduct: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				id: number;
+			};
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['UpdateProductRequest'];
+			};
+		};
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
+	deleteProduct: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				id: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
+	updateOrder: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['UpdateOrderRequest'];
+			};
+		};
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
+	createOrder: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['CreateOrderRequest'];
+			};
+		};
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': number;
+				};
+			};
+		};
+	};
+	getAccountDetail: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				id: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': components['schemas']['GetAccountDetailResponse'];
+				};
+			};
+		};
+	};
+	updateAccount: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				id: number;
+			};
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['UpdateAccountRequest'];
+			};
+		};
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
+	deleteAccount: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				id: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
+	getProductList: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': components['schemas']['GetProductListResponse'][];
+				};
+			};
+		};
+	};
+	createProduct: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['CreateProductRequest'];
+			};
+		};
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': number;
+				};
+			};
+		};
+	};
+	processOrderItems: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['ProcessOrderItemsRequest'];
+			};
+		};
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
+	getAccountList: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': components['schemas']['GetAccountListResponse'][];
+				};
+			};
+		};
+	};
+	createAccount: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['CreateAccountRequest'];
+			};
+		};
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': number;
+				};
+			};
+		};
+	};
+	createOrderPrecondition: {
+		parameters: {
+			query: {
+				count: number;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': string;
+				};
+			};
+		};
+	};
+	getProductBatch: {
+		parameters: {
+			query: {
+				ids: number[];
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': components['schemas']['GetProductDetailResponse'][];
+				};
+			};
+		};
+	};
+	getOrderDetails: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				orderId: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': components['schemas']['GetOrderDetailResponse'];
+				};
+			};
+		};
+	};
+	deleteOrder: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				orderId: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
+	getOrderList: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				accountId: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': components['schemas']['GetOrderListResponse'][];
+				};
+			};
+		};
+	};
+	AccountIdIsInOrder: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				accountId: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OK */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'*/*': boolean;
+				};
+			};
+		};
+	};
 }

--- a/services/schema/api-types.ts
+++ b/services/schema/api-types.ts
@@ -337,6 +337,38 @@ export interface components {
 	headers: never;
 	pathItems: never;
 }
+/**
+ * 分頁回應的通用型別
+ * 用於包裝分頁資料的標準格式
+ */
+export interface PageResponse<T> {
+	content: T[];
+	pageable: {
+		pageNumber: number;
+		pageSize: number;
+		sort: {
+			sorted: boolean;
+			unsorted: boolean;
+			empty: boolean;
+		};
+		offset: number;
+		paged: boolean;
+		unpaged: boolean;
+	};
+	totalPages: number;
+	totalElements: number;
+	last: boolean;
+	size: number;
+	number: number;
+	sort: {
+		sorted: boolean;
+		unsorted: boolean;
+		empty: boolean;
+	};
+	numberOfElements: number;
+	first: boolean;
+	empty: boolean;
+}
 export type $defs = Record<string, never>;
 export interface operations {
 	getProductDetail: {

--- a/tests/api/springboot/order.spec.ts
+++ b/tests/api/springboot/order.spec.ts
@@ -77,9 +77,32 @@ test.describe('Order 訂單管理 (含明細更新)', () => {
 
 	test('應該能根據帳號查詢訂單列表', async ({ springbootApi, existingMultipleOrdersAccountId }) => {
 		const response = await springbootApi.listOrdersByAccount(existingMultipleOrdersAccountId);
-		const list = expectOk(response);
+		const pageResponse = expectOk(response);
 
-		expect(Array.isArray(list)).toBeTruthy();
+		// 驗證分頁回應結構
+		expect(pageResponse).toHaveProperty('content');
+		expect(pageResponse).toHaveProperty('totalElements');
+		expect(pageResponse).toHaveProperty('totalPages');
+		expect(Array.isArray(pageResponse.content)).toBeTruthy();
+		expect(pageResponse.content.length).toBeGreaterThan(0);
+	});
+
+	test('應該能使用分頁參數查詢訂單列表', async ({
+		springbootApi,
+		existingMultipleOrdersAccountId,
+	}) => {
+		// 使用分頁參數查詢
+		const response = await springbootApi.listOrdersByAccount(existingMultipleOrdersAccountId, {
+			page: 0,
+			size: 1,
+			sort: 'id,desc',
+		});
+		const pageResponse = expectOk(response);
+
+		// 驗證分頁參數生效
+		expect(pageResponse.size).toBe(1);
+		expect(pageResponse.number).toBe(0);
+		expect(pageResponse.content.length).toBeLessThanOrEqual(1);
 	});
 
 	test('應該能刪除訂單', async ({ springbootApi, existingOrder }) => {

--- a/tests/api/springboot/order.spec.ts
+++ b/tests/api/springboot/order.spec.ts
@@ -102,7 +102,7 @@ test.describe('Order 訂單管理 (含明細更新)', () => {
 		// 嘗試建立一個訂單數量大於庫存的訂單
 		const response = await springbootApi.createOrder({
 			accountId: existingAccount.id,
-			orderDetails: [{ productId: existingProductId, quantity: availableQuantity + 1 }],
+			items: [{ productId: existingProductId, quantity: availableQuantity + 1 }],
 		});
 
 		const errorBody = expectError(response, 400);

--- a/tests/api/springboot/order.spec.ts
+++ b/tests/api/springboot/order.spec.ts
@@ -101,7 +101,7 @@ test.describe('Order 訂單管理 (含明細更新)', () => {
 
 		// 驗證分頁參數生效
 		expect(pageResponse.size).toBe(1);
-		expect(pageResponse.number).toBe(0);
+		expect(pageResponse.page).toBe(0);
 		expect(pageResponse.content.length).toBeLessThanOrEqual(1);
 	});
 


### PR DESCRIPTION
## 變更摘要
更新 Playwright API client 以配合 Spring Boot 後端的 Breaking Change (commit d8761e8)

## 變更內容
- 將 `CreateOrderRequest` 的 `orderDetails` 欄位改為 `items`
- 更新所有相關的測試案例和 fixtures
- 確保與後端 API 規格完全相容

## 變更檔案
- `services/schema/api-types.ts`
- `services/fixtures/springboot-test-data.fixture.ts`
- `services/fixtures/springboot-api-objects.fixture.ts`
- `tests/api/springboot/order.spec.ts`