### PR TITLE
docs(git): 改進 PR 描述建議，強調 labels 重要性並移除冗餘內容

### DIFF
--- a/docs/agents/05-git-workflow.md
+++ b/docs/agents/05-git-workflow.md
@@ -128,13 +128,42 @@ remote:      https://github.com/junechen7414/Playwright-TS/pull/new/feature/your
 
 ### PR 標題和描述建議
 
-- **標題格式**：遵循 Conventional Commits 格式
-  - 範例：`feat(auth): add login functionality`
-- **描述內容**：
-  - 簡述變更內容
-  - 列出主要修改項目
-  - 如有相關 issue，使用 `Closes #123` 連結
-  - 如有破壞性變更，明確標註 `BREAKING CHANGE`
+#### 標題格式
+遵循 Conventional Commits 格式：
+- 範例：`feat(auth): add login functionality`
+- 範例：`docs(git): 更新 Git 工作流程說明`
+
+#### 描述內容
+**應該包含：**
+- ✅ 變更的目的和背景
+- ✅ 主要功能或改進說明
+- ✅ 相關 issue 連結（使用 `Closes #123`）
+- ✅ 破壞性變更說明（使用 `BREAKING CHANGE`）
+
+**不需要包含：**
+- ❌ 修改的檔案列表（GitHub 會自動顯示）
+- ❌ 測試結果（CI/CD 會自動執行並顯示）
+- ❌ 程式碼細節（可在 Files changed 中查看）
+
+#### Labels 選擇
+**必須為 PR 加上適當的 labels**，根據變更性質選擇 1-2 個最相關的：
+
+| 變更類型 | 建議 Label |
+|---------|-----------|
+| 文件更新 | `documentation` |
+| 新功能 | `enhancement` |
+| 錯誤修復 | `bugfix` |
+| 程式碼重構 | `refactor` |
+| 測試相關 | `test` 或 `e2e-test` |
+| 依賴更新 | `dependencies` |
+| 配置變更 | `config` |
+| 破壞性變更 | `breaking-change` |
+| 建置/工具 | `chore` |
+
+**範例：**
+- 文件更新的 PR → 加上 `documentation` label
+- 新增測試的 PR → 加上 `e2e-test` label
+- 重構程式碼的 PR → 加上 `refactor` label
 
 ## 分支清理
 
@@ -221,7 +250,6 @@ git push origin --delete feature/add-login-page
 | `e2e-test` | E2E 測試相關 |
 | `enhancement` | 功能增強 |
 | `refactor` | 程式碼重構 |
-| `test` | 測試相關 |
 
 **Agent 建議流程**：建立 PR 時應根據改動性質選擇 1-2 個最相關的 labels。
 

--- a/docs/agents/05-git-workflow.md
+++ b/docs/agents/05-git-workflow.md
@@ -98,8 +98,10 @@ updated readme  # 缺少 type
 4. BOB 會自動：
    - 分析 commit 歷史
    - 生成 PR 標題和描述
-   - 選擇適當的 labels
    - 建立 Pull Request
+5. **重要**：建立 PR 後，請根據變更類型手動添加適當的 labels（參考下方「Labels 選擇」章節）
+
+> **注意**：目前 `/create-pr` 指令尚未支援自動添加 labels，需要在 GitHub 網頁上手動添加。未來版本可能會加入此功能。
 
 ### 手動建立 PR
 


### PR DESCRIPTION
## 📋 變更目的

改進 Git 工作流程文件中的 PR 建立指南，使其更符合實務最佳實踐。

## 🎯 主要改進

### PR 描述內容優化
- 明確區分「應該包含」和「不需要包含」的內容
- 避免重複 GitHub 和 CI/CD 已提供的資訊（檔案列表、測試結果）
- 聚焦於變更的目的、背景和影響

### 強調 Labels 重要性
- 新增「Labels 選擇」專門章節
- 提供完整的 label 類型對照表
- 根據不同變更類型給出明確的 label 建議
- 包含實際使用範例

### 改善文件結構
- 使用清楚的小標題組織內容
- 採用表格呈現 label 對照關係
- 提供具體範例說明

## 💡 為什麼需要這個改進

1. **避免資訊重複**：GitHub 的 Files changed 和 CI/CD 已經提供檔案列表和測試結果
2. **提升 PR 品質**：引導開發者關注變更的「為什麼」而非「是什麼」
3. **標準化流程**：透過 label 對照表，建議適合的標籤