### PR TITLE
test(api): 串接 HTTP Basic 認證憑證至測試堆疊與 CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,12 @@
 
 ORACLE_TEST_USERNAME=your_real_username
 ORACLE_TEST_PASSWORD=your_real_password
+
+# Spring Boot API HTTP Basic 認證
+# ================================
+# 後端在 PR #66 後對 /account、/product、/order 等端點加上 HTTP Basic 認證。
+# E2E 為外部呼叫端，應使用 api 帳號（internal 帳號僅供 backend loopback 自呼叫）。
+# 未設定時，Playwright 與後端容器皆會落回預設值 api / local-api-secret，可開箱即用。
+# CI 環境請於 GitHub Secrets 設定 API_USERNAME / API_PASSWORD（正式環境用強密碼）。
+API_USERNAME=api
+API_PASSWORD=local-api-secret

--- a/.github/workflows/springboot.yml
+++ b/.github/workflows/springboot.yml
@@ -67,6 +67,8 @@ jobs:
           ORACLE_TEST_PASSWORD: ${{ secrets.DB_PASSWORD }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           IMAGE_TAG: ${{ steps.set-tag.outputs.IMAGE_TAG }}
+          API_USERNAME: ${{ secrets.API_USERNAME }}
+          API_PASSWORD: ${{ secrets.API_PASSWORD }}
         run: |
           echo "🚀 Starting environment with image tag: $IMAGE_TAG"
           # --wait 會等待 Dockerfile 中的 HEALTHCHECK 成功
@@ -101,6 +103,9 @@ jobs:
         env:
           # 指向剛啟動的 Docker 容器位址 (通常是 localhost:8787)
           BASE_URL: http://localhost:8787
+          # HTTP Basic 認證憑證：與後端容器同一組值，Playwright 據此送出 Authorization 標頭
+          API_USERNAME: ${{ secrets.API_USERNAME }}
+          API_PASSWORD: ${{ secrets.API_PASSWORD }}
           
       - name: Stop Environment
         if: always()

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,6 +13,10 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:oracle:thin:@oracle-db:1521/FREEPDB1
       - SPRING_DATASOURCE_USERNAME=${ORACLE_TEST_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${ORACLE_TEST_PASSWORD}
+      # HTTP Basic 認證憑證：覆寫後端 app.auth.api-*，與 Playwright 送出的標頭同步
+      # 提供 fallback 預設值，避免 secret 未設定時傳入空字串觸發 @NotBlank 導致啟動失敗
+      - API_USERNAME=${API_USERNAME:-api}
+      - API_PASSWORD=${API_PASSWORD:-local-api-secret}
     networks:
       - test-net
     depends_on:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// 外部 API 呼叫端憑證：CI 由 GitHub Secrets 帶入，本機用預設值
+const API_USERNAME = process.env.API_USERNAME || 'api';
+const API_PASSWORD = process.env.API_PASSWORD || 'local-api-secret';
+const BASIC_AUTH = `Basic ${Buffer.from(`${API_USERNAME}:${API_PASSWORD}`).toString('base64')}`;
+
 /**
  * 建立時間戳記 (優化可讀性)
  */
@@ -63,7 +68,11 @@ export default defineConfig({
 			name: 'springboot-api',
 			testMatch: '**/springboot/*.spec.ts',
 			use: {
-				baseURL: 'http://localhost:8787/', // 對應你 docker-compose 的 port
+				baseURL: process.env.BASE_URL || 'http://localhost:8787/', // 對應你 docker-compose 的 port
+				// 每次請求主動帶 HTTP Basic 標頭，覆蓋全部測試與 fixtures，無 401→retry 往返
+				extraHTTPHeaders: {
+					Authorization: BASIC_AUTH,
+				},
 			},
 		},
 


### PR DESCRIPTION
後端 PR #66 後對 API 端點加上 HTTP Basic 認證，將憑證串接至
compose、Playwright config 與 CI workflow，並提供 api/local-api-secret fallback 讓本機開箱即用。